### PR TITLE
Splitting partition by by comma

### DIFF
--- a/dagger/dag_creator/airflow/operators/aws_athena_operator.py
+++ b/dagger/dag_creator/airflow/operators/aws_athena_operator.py
@@ -95,7 +95,7 @@ INSERT INTO {self.database}.{self.output_table}
         }
 
         if self.partitioned_by:
-            partitioned_by_str = ','.join([f"'{column}'" for column in self.partitioned_by])
+            partitioned_by_str = ','.join([f"'{column}'" for column in self.partitioned_by.split(',')])
             with_parameters_dict['partitioned_by'] = f"ARRAY[{partitioned_by_str}]"
 
         if self.output_format:


### PR DESCRIPTION
In the athena transformation, atm partitioned_by attribute was split by characters instead of split by comma.