### PR TITLE
Fixing attribute type

### DIFF
--- a/dagger/pipeline/tasks/athena_transform_task.py
+++ b/dagger/pipeline/tasks/athena_transform_task.py
@@ -53,7 +53,7 @@ class AthenaTransformTask(Task):
                 Attribute(
                     attribute_name="partitioned_by",
                     required=False,
-                    validator=list,
+                    validator=str,
                     comment="The list of fields to partition by. These fields should come last in the select statement",
                     parent_fields=["task_parameters"],
                 ),


### PR DESCRIPTION
The attribute's validator was list, but we need string, so we can split into a list later