### PR TITLE
Added new attribute supporting altering columns of infered redshift s…

### DIFF
--- a/dagger/pipeline/tasks/redshift_load_task.py
+++ b/dagger/pipeline/tasks/redshift_load_task.py
@@ -84,6 +84,14 @@ class RedshiftLoadTask(Task):
                     comment="If you have the schema of the table e.g.: in spectrum you can copy the ddl from there",
                 ),
                 Attribute(
+                    attribute_name="alter_columns",
+                    required=False,
+                    parent_fields=["task_parameters"],
+                    format_help="comma separated strings as <column_name>:<column_type>,<column_name:column_type>",
+                    comment="If you want to alter the column types that are inferred from the "
+                            "redshift spectrum table given in the copy_ddl_from parameter"
+                ),
+                Attribute(
                     attribute_name="sort_keys",
                     required=False,
                     parent_fields=["task_parameters"],
@@ -107,6 +115,7 @@ class RedshiftLoadTask(Task):
         self._tmp_table_prefix = self.parse_attribute("tmp_table_prefix")
         self._create_table_ddl = self.parse_attribute("create_table_ddl")
         self._copy_ddl_from = self.parse_attribute("copy_ddl_from")
+        self._alter_columns = self.parse_attribute("alter_columns")
         load_parameters = self._get_default_load_params()
         if self._max_errors:
             load_parameters["maxerrors"] = self._max_errors
@@ -153,6 +162,10 @@ class RedshiftLoadTask(Task):
     @property
     def copy_ddl_from(self):
         return self._copy_ddl_from
+
+    @property
+    def alter_columns(self):
+        return self._alter_columns
 
     @property
     def sort_keys(self):


### PR DESCRIPTION
Redshift loader infers schema from glue. In glue we have dynamic length strings, but in redshift the we have fixed length strings, however sometimes the default length in the inferred schema is not long enough and that fails the redshift copy command.

With the newly added parameter we are able to alter the type of the inferred columns.