### PR TITLE
Feature/data 1300 blue gree athena transformation

### DIFF
--- a/dagger/dag_creator/airflow/hooks/aws_athena_hook.py
+++ b/dagger/dag_creator/airflow/hooks/aws_athena_hook.py
@@ -97,6 +97,17 @@ class AWSAthenaHook(AwsBaseHook):
         bucket = s3.Bucket(s3_bucket)
         bucket.objects.filter(Prefix=f"{path.join(s3_path, database, table)}/").delete()
 
+    def search_tables(self, database, table_name_pattern):
+        response = self.get_glue_conn().get_tables(
+            DatabaseName=database,
+            Expression=table_name_pattern,
+            MaxResults=5
+        )
+
+        table_names = [table['Name'] for table in response['TableList']]
+
+        return table_names
+
     def run_query(self, query, query_context, result_configuration, client_request_token=None,
                   workgroup='primary'):
         """

--- a/dagger/dag_creator/airflow/operator_creators/athena_transform_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/athena_transform_creator.py
@@ -38,6 +38,7 @@ class AthenaTransformCreator(OperatorCreator):
             is_incremental=self._task.is_incremental,
             partitioned_by=self._task.partitioned_by,
             output_format=self._task.output_format,
+            blue_green_deployment=self._task.blue_green_deployment,
             workgroup=self._task.workgroup,
             params=self._template_parameters,
             **kwargs,

--- a/dagger/pipeline/tasks/athena_transform_task.py
+++ b/dagger/pipeline/tasks/athena_transform_task.py
@@ -63,6 +63,13 @@ class AthenaTransformTask(Task):
                     validator=str,
                     comment="Output file format. One of PARQUET/ORC/JSON/CSV",
                     parent_fields=["task_parameters"],
+                ),
+                Attribute(
+                    attribute_name="blue_green_deployment",
+                    required=False,
+                    validator=bool,
+                    comment="Set to true for blue green deployment. Only works with non incremental transformations.",
+                    parent_fields=["task_parameters"],
                 )
             ]
         )
@@ -82,6 +89,7 @@ class AthenaTransformTask(Task):
         self._is_incremental = self.parse_attribute("is_incremental")
         self._partitioned_by = self.parse_attribute("partitioned_by")
         self._output_format = self.parse_attribute("output_format")
+        self._blue_green_deployment = self.parse_attribute("blue_green_deployment") or False
 
         self._add_hidden_s3_output()
 
@@ -116,6 +124,10 @@ class AthenaTransformTask(Task):
     @property
     def output_format(self):
         return self._output_format
+
+    @property
+    def blue_green_deployment(self):
+        return self._blue_green_deployment
 
     def _add_hidden_s3_output(self):
         output_athena = self._outputs[0]


### PR DESCRIPTION
**JIRA Ticket:**
[DATA-1300](https://choco.atlassian.net/browse/DATA-1300)

**Notes**
1. Adding new boolean attribute to flag if we want to do blue green deployment for non incremental athena transformations
2. Adding logic to implement blue green. The idea is that we are crating staging tables with randomised table names like `__<original output_table_name>_random_sequence` and when it's ready we are just pointing a view to the newly created table.
3. As a last step we clean up the old tables. For this step even before we run the new tansformations, we store all the tables that has the `__<original output_table_name>_*` pattern and then at the end if all previous steps are successful then drop them.

Tested fully from local airflow running on staging environment.