### PR TITLE
Removing unneccessary parameter

### DIFF
--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -137,7 +137,6 @@ class RedshiftLoadCreator(OperatorCreator):
             task_id=self._task.name,
             sql=load_cmd,
             redshift_conn_id=self._task.postgres_conn_id,
-            split_parameters=True,
             autocommit=True,
             **kwargs
         )


### PR DESCRIPTION
Removing unnecessary parameter. Splitting statements will by default passed to the hook. 