### PR TITLE
Adding retry with tenacity

### DIFF
--- a/dagger/dag_creator/airflow/operators/aws_athena_operator.py
+++ b/dagger/dag_creator/airflow/operators/aws_athena_operator.py
@@ -24,6 +24,7 @@ from dagger.dag_creator.airflow.operators.dagger_base_operator import DaggerBase
 from airflow.utils.decorators import apply_defaults
 from dagger.dag_creator.airflow.hooks.aws_athena_hook import AWSAthenaHook
 from dagger.utilities.randomise import generate_random_name
+from tenacity import retry, stop_after_attempt, wait_fixed
 from os import path
 
 
@@ -130,6 +131,7 @@ AS {self.query}
         else:
             return self.build_ctas_query(output_table_name)
 
+    @retry(stop=stop_after_attempt(3), wait=wait_fixed(60))
     def cleanup_table(self, table_name):
         self.log.info(f"Dropping table: {self.database}.{table_name}")
         self.hook.drop_table(self.database, table_name)

--- a/reqs/base.txt
+++ b/reqs/base.txt
@@ -4,3 +4,4 @@ envyaml==1.10.211231
 mergedeep==1.3.4
 slack==0.0.2
 slackclient==2.9.4
+tenacity==8.0.1


### PR DESCRIPTION
We have some failures during cleanup when we delete all partitions of the temp tables because of S3 SlowDown. In these cases the job runs from scratch which means that the cleanup will need to clean even more data for the second time. Instead retying the full task, added retry just for the cleanup function inside the operator