### PR TITLE
changed how the input path is used in the redshift loader

### DIFF
--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -147,7 +147,7 @@ class RedshiftLoadCreator(OperatorCreator):
         if self._tmp_table is None:
             return None
 
-        return f"DROP TABLE IF EXISTS {self._output_schema_quoted}.{self._tmp_table_quoted};\n"
+        return f"DROP TABLE IF EXISTS {self._output_schema_quoted}.{self._tmp_table_quoted}"
 
     def _get_cmd(self) -> str:
         raw_load_cmd = [

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -11,7 +11,7 @@ class RedshiftLoadCreator(OperatorCreator):
     def __init__(self, task, dag):
         super().__init__(task, dag)
 
-        self._input_path = self._task.inputs[0].rendered_name
+        self._input_path = join(self._task.inputs[0].rendered_name, "")
         self._input_s3_bucket = self._task.inputs[0].bucket
         self._input_s3_prefix = self._task.inputs[0].path
 

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -147,8 +147,7 @@ class RedshiftLoadCreator(OperatorCreator):
         if self._tmp_table is None:
             return None
 
-        return
-        f"DROP TABLE IF EXISTS {self._output_schema_quoted}.{self._tmp_table_quoted};\n"
+        return f"DROP TABLE IF EXISTS {self._output_schema_quoted}.{self._tmp_table_quoted};\n"
 
     def _get_cmd(self) -> str:
         raw_load_cmd = [

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -115,8 +115,16 @@ class RedshiftLoadCreator(OperatorCreator):
 
         return ";\n".join(alter_column_commands)
 
+    def _get_drop_tmp_table_cmd(self) -> Optional[str]:
+        if self._tmp_table is None:
+            return None
+
+        return
+        f"DROP TABLE IF EXISTS {self._output_schema_quoted}.{self._tmp_table_quoted};\n"
+
     def _get_cmd(self) -> str:
         raw_load_cmd = [
+            self._get_drop_tmp_table_cmd(),
             self._get_create_table_cmd(),
             self._get_alter_columns_cmd(),
             self._get_sort_key_cmd(),

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -2,7 +2,9 @@ from os.path import join
 from typing import Optional
 
 from dagger.dag_creator.airflow.operator_creator import OperatorCreator
-from dagger.dag_creator.airflow.operators.redshift_sql_operator import RedshiftSQLOperator
+from dagger.dag_creator.airflow.operators.redshift_sql_operator import (
+    RedshiftSQLOperator,
+)
 
 
 class RedshiftLoadCreator(OperatorCreator):
@@ -17,11 +19,15 @@ class RedshiftLoadCreator(OperatorCreator):
 
         self._output_schema = self._task.outputs[0].schema
         self._output_table = self._task.outputs[0].table
-        self._output_schema_quoted = f"\"{self._output_schema}\""
-        self._output_table_quoted = f"\"{self._output_table}\""
+        self._output_schema_quoted = f'"{self._output_schema}"'
+        self._output_table_quoted = f'"{self._output_table}"'
 
-        self._tmp_table = f"{self._task.tmp_table_prefix}_{self._output_table}" if self._task.tmp_table_prefix else None
-        self._tmp_table_quoted = f"\"{self._tmp_table}\"" if self._tmp_table else None
+        self._tmp_table = (
+            f"{self._task.tmp_table_prefix}_{self._output_table}"
+            if self._task.tmp_table_prefix
+            else None
+        )
+        self._tmp_table_quoted = f'"{self._tmp_table}"' if self._tmp_table else None
 
         self._copy_ddl_from = self._task.copy_ddl_from
         self._alter_columns = self._task.alter_columns
@@ -39,35 +45,54 @@ class RedshiftLoadCreator(OperatorCreator):
 
     def _get_create_table_cmd(self) -> Optional[str]:
         if self._tmp_table and self._task.create_table_ddl:
-            ddl = self._read_sql(self._task.pipeline.directory, self._task.create_table_ddl)
-            return ddl.format(schema_name=self._output_schema_quoted, table_name=self._tmp_table_quoted)
+            ddl = self._read_sql(
+                self._task.pipeline.directory, self._task.create_table_ddl
+            )
+            return ddl.format(
+                schema_name=self._output_schema_quoted,
+                table_name=self._tmp_table_quoted,
+            )
         if self._tmp_table and self._copy_ddl_from:
-            return f"CREATE TABLE {self._output_schema_quoted}.{self._tmp_table_quoted}" \
-                   f"(LIKE {self._copy_ddl_from})"
+            return (
+                f"CREATE TABLE {self._output_schema_quoted}.{self._tmp_table_quoted}"
+                f"(LIKE {self._copy_ddl_from})"
+            )
         elif self._tmp_table:
-            return f"CREATE TABLE {self._output_schema_quoted}.{self._tmp_table_quoted}" \
-                   f"(LIKE {self._output_schema_quoted}.{self._output_table_quoted})"
+            return (
+                f"CREATE TABLE {self._output_schema_quoted}.{self._tmp_table_quoted}"
+                f"(LIKE {self._output_schema_quoted}.{self._output_table_quoted})"
+            )
         elif self._task.create_table_ddl:
-            ddl = self._read_sql(self._task.pipeline.directory, self._task.create_table_ddl)
-            return ddl.format(schema_name=self._output_schema_quoted, table_name=self._output_table_quoted)
+            ddl = self._read_sql(
+                self._task.pipeline.directory, self._task.create_table_ddl
+            )
+            return ddl.format(
+                schema_name=self._output_schema_quoted,
+                table_name=self._output_table_quoted,
+            )
         elif self._copy_ddl_from:
-            return f"CREATE TABLE IF NOT EXISTS {self._output_schema_quoted}.{self._output_table}" \
-                   f"(LIKE {self._copy_ddl_from})"
+            return (
+                f"CREATE TABLE IF NOT EXISTS {self._output_schema_quoted}.{self._output_table}"
+                f"(LIKE {self._copy_ddl_from})"
+            )
 
         return None
 
     def _get_sort_key_cmd(self) -> Optional[str]:
         sort_key_cmd = None
         if self._sort_keys:
-            sort_key_cmd =\
-                f"ALTER TABLE {self._output_schema_quoted}.{self._tmp_table_quoted} " \
+            sort_key_cmd = (
+                f"ALTER TABLE {self._output_schema_quoted}.{self._tmp_table_quoted} "
                 f"ALTER COMPOUND SORTKEY({self._sort_keys})"
+            )
         return sort_key_cmd
 
     def _get_delete_cmd(self) -> Optional[str]:
         if self._task.incremental:
-            return f"DELETE FROM {self._output_schema_quoted}.{self._output_table_quoted}" \
-                   f"WHERE {self._task.delete_condition}"
+            return (
+                f"DELETE FROM {self._output_schema_quoted}.{self._output_table_quoted}"
+                f"WHERE {self._task.delete_condition}"
+            )
 
         if not self._task.incremental and self._tmp_table is None:
             return f"TRUNCATE TABLE {self._output_schema_quoted}.{self._output_table_quoted}"
@@ -84,21 +109,24 @@ class RedshiftLoadCreator(OperatorCreator):
             ]
         )
 
-        return f"copy {self._output_schema_quoted}.{table_name}{columns}\n" \
-               f"from '{self._input_path}'\n" \
-               f"iam_role '{self._task.iam_role}'\n" \
-               f"{extra_parameters}"
+        return (
+            f"copy {self._output_schema_quoted}.{table_name}{columns}\n"
+            f"from '{self._input_path}'\n"
+            f"iam_role '{self._task.iam_role}'\n"
+            f"{extra_parameters}"
+        )
 
     def _get_replace_table_cmd(self) -> Optional[str]:
         if self._tmp_table is None:
             return None
 
-        return \
-            f"BEGIN TRANSACTION;\n" \
-            f"DROP TABLE IF EXISTS {self._output_schema_quoted}.{self._output_table_quoted};\n" \
-            f"ALTER TABLE {self._output_schema_quoted}.{self._tmp_table_quoted} " \
-            f"RENAME TO {self._output_table_quoted};\n" \
+        return (
+            f"BEGIN TRANSACTION;\n"
+            f"DROP TABLE IF EXISTS {self._output_schema_quoted}.{self._output_table_quoted};\n"
+            f"ALTER TABLE {self._output_schema_quoted}.{self._tmp_table_quoted} "
+            f"RENAME TO {self._output_table_quoted};\n"
             f"END"
+        )
 
     def _get_alter_columns_cmd(self) -> Optional[str]:
         if self._alter_columns is None:
@@ -130,12 +158,12 @@ class RedshiftLoadCreator(OperatorCreator):
             self._get_sort_key_cmd(),
             self._get_delete_cmd(),
             self._get_load_cmd(),
-            self._get_replace_table_cmd()
+            self._get_replace_table_cmd(),
         ]
 
         load_cmd = [cmd for cmd in raw_load_cmd if cmd]
 
-        return ';\n'.join(load_cmd)
+        return ";\n".join(load_cmd)
 
     def _create_operator(self, **kwargs):
         load_cmd = self._get_cmd()
@@ -146,6 +174,6 @@ class RedshiftLoadCreator(OperatorCreator):
             sql=load_cmd,
             redshift_conn_id=self._task.postgres_conn_id,
             autocommit=True,
-            **kwargs
+            **kwargs,
         )
         return redshift_op


### PR DESCRIPTION
The problem with using the redshift loader right now is that when the path is read from the s3 input, the 

```sql
CREATE TABLE <table name> from <path>
```
where `path = x/y/z`, uses this `path` as a prefix. This means that all files that have the path as a prefix would be loaded(like `x/y/z*`). 

This behaviour breaks the redshift loaders when there are two objects(in this case dbt models) that have the same prefix path.

This PR adds the behavior such that the input paths always contain a trailing backslash

# Checklist

- [x] Tested on datatst
<img width="842" alt="image" src="https://user-images.githubusercontent.com/16002904/217306991-128c913a-f709-4995-8c99-3707d1229bca.png">
