### PR TITLE
Feature: Add the new mandatory dbt command parameter

### DIFF
--- a/dagger/dag_creator/airflow/operator_creators/dbt_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/dbt_creator.py
@@ -14,12 +14,14 @@ class DbtCreator(BatchCreator):
         self._profile_dir = task.profile_dir
         self._profile_name = task.profile_name
         self._select = task.select
+        self._dbt_command = task.dbt_command
 
     def _generate_command(self):
         command = [self._task.executable_prefix, self._task.executable]
         command.append(f"--project_dir={self._project_dir}")
         command.append(f"--profiles_dir={self._profile_dir}")
         command.append(f"--profile_name={self._profile_name}")
+        command.append(f"--dbt_command={self._dbt_command}")
         if self._select:
             command.append(f"--select={self._select}")
 
@@ -29,7 +31,8 @@ class DbtCreator(BatchCreator):
 
         return command
 
-    # Overwriting function because for dbt we don't want to add inputs/outputs to the template parameters
+    # Overwriting function because for dbt we don't want to add inputs/outputs to the
+    # template parameters.
     def create_operator(self):
         self._template_parameters.update(self._task.template_parameters)
         self._update_airflow_parameters()

--- a/dagger/pipeline/tasks/dbt_task.py
+++ b/dagger/pipeline/tasks/dbt_task.py
@@ -23,13 +23,19 @@ class DbtTask(BatchTask):
                     attribute_name="profile_name",
                     required=False,
                     parent_fields=["task_parameters"],
-                    comment="Which target to load for the given profile (--target dbt option). Default is 'default'",
+                    comment="Which target to load for the given profile "
+                            "(--target dbt option). Default is 'default'",
                 ),
                 Attribute(
                     attribute_name="select",
                     required=False,
                     parent_fields=["task_parameters"],
                     comment="Specify the nodes to include (--select dbt option)",
+                ),
+                Attribute(
+                    attribute_name="dbt_command",
+                    parent_fields=["task_parameters"],
+                    comment="Specify the name of the DBT command to run",
                 ),
             ]
         )
@@ -41,6 +47,7 @@ class DbtTask(BatchTask):
         self._profile_dir = self.parse_attribute("profile_dir")
         self._profile_name = self.parse_attribute("profile_name") or "default"
         self._select = self.parse_attribute("select")
+        self._dbt_command = self.parse_attribute("dbt_command")
 
     @property
     def project_dir(self):
@@ -57,3 +64,7 @@ class DbtTask(BatchTask):
     @property
     def select(self):
         return self._select
+
+    @property
+    def dbt_command(self):
+        return self._dbt_command


### PR DESCRIPTION
### Solution description
- Add the new mandatory `dbt_command` parameter. This way, we can customise the dbt operation and not only use the default `build` by other processes.