### PR TITLE
Feature / full_refresh is dbt task parameter

### DIFF
--- a/dagger/dag_creator/airflow/operator_creators/dbt_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/dbt_creator.py
@@ -15,6 +15,7 @@ class DbtCreator(BatchCreator):
         self._profile_name = task.profile_name
         self._select = task.select
         self._dbt_command = task.dbt_command
+        self._full_refresh = task.full_refresh
 
     def _generate_command(self):
         command = [self._task.executable_prefix, self._task.executable]
@@ -28,6 +29,9 @@ class DbtCreator(BatchCreator):
         if len(self._template_parameters) > 0:
             dbt_vars = json.dumps(self._template_parameters)
             command.append(f"--vars='{dbt_vars}'")
+
+        if self._full_refresh:
+            command.append(f"--full-refresh")
 
         return command
 

--- a/dagger/pipeline/tasks/dbt_task.py
+++ b/dagger/pipeline/tasks/dbt_task.py
@@ -37,6 +37,12 @@ class DbtTask(BatchTask):
                     parent_fields=["task_parameters"],
                     comment="Specify the name of the DBT command to run",
                 ),
+                Attribute(
+                    attribute_name="full_refresh",
+                    required=False,
+                    parent_fields=["task_parameters"],
+                    comment="Boolean to specify if the model run should be a full refresh",
+                ),
             ]
         )
 
@@ -48,6 +54,7 @@ class DbtTask(BatchTask):
         self._profile_name = self.parse_attribute("profile_name") or "default"
         self._select = self.parse_attribute("select")
         self._dbt_command = self.parse_attribute("dbt_command")
+        self._full_refresh = self.parse_attribute("full_refresh")
 
     @property
     def project_dir(self):
@@ -68,3 +75,7 @@ class DbtTask(BatchTask):
     @property
     def dbt_command(self):
         return self._dbt_command
+
+    @property
+    def full_refresh(self):
+        return self._full_refresh


### PR DESCRIPTION
Moving forward we would like to have the --full-refresh flag as a dbt command parameter.

For now this flag is included in the select command. ex `--select=model_name --full-refresh`
Removing this hacky setup would enable us to get the model_name in the Airflow task parameters.

This will be necessary to implement a rs loader task in our dbt_backfill job