### PR TITLE
Feature/postgres list columns

### DIFF
--- a/dagger/dag_creator/airflow/operators/postgres_operator.py
+++ b/dagger/dag_creator/airflow/operators/postgres_operator.py
@@ -46,6 +46,8 @@ class PostgresOperator(DaggerBaseOperator):
         self.parameters = parameters
         self.database = database
 
+        self._unpack_columns()
+
     def _unpack_columns(self):
         """
         Unpacks columns from parameters dict into a string

--- a/dagger/dag_creator/airflow/operators/postgres_operator.py
+++ b/dagger/dag_creator/airflow/operators/postgres_operator.py
@@ -46,6 +46,19 @@ class PostgresOperator(DaggerBaseOperator):
         self.parameters = parameters
         self.database = database
 
+        self._unpack_columns()
+
+    def _unpack_columns(self):
+        """
+        Unpacks columns from parameters dict into a string
+        """
+        # if parameters exists and is dict and has columns
+        if (
+            self.parameters
+            and isinstance(self.parameters, dict)
+            and "columns" in self.parameters):
+                self.parameters["columns"] = ", ".join(self.parameters["columns"])
+
     def execute(self, context):
         self.log.info("Executing: %s", self.sql)
         self.hook = PostgresHook(

--- a/dagger/dag_creator/airflow/operators/postgres_operator.py
+++ b/dagger/dag_creator/airflow/operators/postgres_operator.py
@@ -57,7 +57,7 @@ class PostgresOperator(DaggerBaseOperator):
             self.parameters
             and isinstance(self.parameters, dict)
             and "columns" in self.parameters):
-                self.parameters["columns"] = ", ".join(self.parameters["columns"])
+                self.parameters["columns"] = ", ".join([f'"{column}"' for column in self.parameters["columns"]])
 
     def execute(self, context):
         self.log.info("Executing: %s", self.sql)

--- a/dagger/dag_creator/airflow/operators/postgres_operator.py
+++ b/dagger/dag_creator/airflow/operators/postgres_operator.py
@@ -30,14 +30,14 @@ class PostgresOperator(DaggerBaseOperator):
 
     @apply_defaults
     def __init__(
-        self,
-        sql: str,
-        postgres_conn_id: str = "postgres_default",
-        autocommit: bool = False,
-        parameters: Optional[Union[Mapping, Iterable]] = None,
-        database: Optional[str] = None,
-        *args,
-        **kwargs,
+            self,
+            sql: str,
+            postgres_conn_id: str = "postgres_default",
+            autocommit: bool = False,
+            parameters: Optional[Union[Mapping, Iterable]] = None,
+            database: Optional[str] = None,
+            *args,
+            **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.sql = sql
@@ -46,18 +46,16 @@ class PostgresOperator(DaggerBaseOperator):
         self.parameters = parameters
         self.database = database
 
-        self._unpack_columns()
-
     def _unpack_columns(self):
         """
         Unpacks columns from parameters dict into a string
         """
         # if parameters exists and is dict and has columns
         if (
-            self.parameters
-            and isinstance(self.parameters, dict)
-            and "columns" in self.parameters):
-                self.parameters["columns"] = ", ".join([f'"{column}"' for column in self.parameters["columns"]])
+                self.parameters
+                and isinstance(self.parameters, dict)
+                and isinstance(self.parameters.get("columns"), list)):
+            self.parameters["columns"] = ", ".join([f'"{column}"' for column in self.parameters["columns"]])
 
     def execute(self, context):
         self.log.info("Executing: %s", self.sql)


### PR DESCRIPTION
The PostgresOperator is currently receiving all SQL parameters as strings. When we configure Redshift loaders and need to select many columns, we have to provide the list as string which is very unwieldy, e.g.:

```
"\"anonymous_id\",\"message_id\",\"user_id\",\"name\",\"event\",\"context_active\",\"context_app_name\",\"context_app_version\",\"context_app_build\",\"context_campaign_name\",\"context_campaign_source\",\"context_campaign_medium\",\"context_campaign_term\",\"context_campaign_content\",\"context_device_id\",\"context_device_advertising_id\",\"context_device_manufacturer\",\"context_device_model\",\"context_device_name\",\"context_device_type\",\"context_device_version\",\"context_ip\",\"context_library\",\"context_locale\",\"context_location\",\"context_network_bluetooth\",\"context_network_carrier\",\"context_network_cellular\",\"context_network_wifi\",\"context_os_name\",\"context_os_version\",\"context_page_path\",\"context_page_referrer\",\"context_page_search\",\"context_page_title\",\"context_support_login\",\"context_page_url\",\"context_referrer_type\",\"context_referrer_name\",\"context_referrer_url\",\"context_referrer_link\",\"context_screen_density\",\"context_screen_height\",\"context_screen_width\",\"context_timezone\",\"context_group_id\",\"context_traits\",\"context_user_agent\",\"version\",\"property_selection\",\"property_chat_id\",\"property_supplier_id\",\"property_order_id\",\"property_buyer_entity_id\",\"property_email\",\"property_product_id\",\"trait_company\",\"trait_age\",\"trait_birthday\",\"trait_first_name\",\"trait_last_name\",\"trait_email\",\"trait_phone\",\"trait_website\",\"trait_title\",\"trait_username\",\"trait_address_city\",\"trait_address_country\",\"trait_google_place_id\",\"trait_name\",\"trait_ref_id\",\"trait_type\",\"original_timestamp\",\"sent_at\",\"event_timestamp\",\"integrations\",\"event_type\",\"_event_id\",\"property_previous_screen\",\"property_search_term\",\"property_customer_number_mandatory\",\"property_supplier_rank_in_search\",\"_created_at\",\"property_broadcast_products_ordered_count\",\"property_reason\",\"property_num_products\",\"property_num_products_with_prices\",\"property_has_some_prices\",\"property_has_all_prices\",\"property_order_value\",\"property_order_currency\",\"property_google_place_id\",\"property_invited_user_phone\",\"property_is_group_order\",\"property_minimum_order_value\",\"property_buyer_role\",\"property_display_team_order_explainer\",\"property_cta_version\",\"property_is_new_choco_user\",\"property_product_quantity\",\"property_is_display_name_changed\",\"property_is_custom_price_changed\",\"property_is_par_changed\",\"property_is_product_name_changed\",\"property_is_units_changed\",\"property_is_product_id_changed\",\"property_is_category_changed\",\"property_status\",\"year\",\"month\",\"day\",\"dt\""
```

This feature allows us to also define columns as list. In that case, the list will be automatically rendered. 