### PR TITLE
DATA-1477 fix: one external sensor for multiple tasks in one DAG

### DIFF
--- a/dagger/dag_creator/airflow/dag_creator.py
+++ b/dagger/dag_creator/airflow/dag_creator.py
@@ -120,7 +120,7 @@ class DagCreator(GraphTraverserBase):
                 re.sub("[^0-9a-zA-Z-_]+", "_", dataset_id), self._dags[pipe_id]
             )
 
-    def _create_edge_without_data(self, from_task_id: str, to_task_ids: list[str], node: Node) -> None:
+    def _create_edge_without_data(self, from_task_id: str, to_task_ids: list, node: Node) -> None:
         """
         Creates an edge between tasks without transferring data.
 


### PR DESCRIPTION
Dagger doesn't have a proper feature to create one external sensor for multiple tasks in the same DAG. It will throw error: `DuplicateTaskIdFound(f"Task id '{task_id}' has already been added to the DAG")` when we set multiple tasks in the same DAG as downstream for a single external sensor.

This PR is to introduce/ fix this feature with a quick solution.

- Issue:
   When we loop over the ` to_task_ids`, we will create a new external task sensor object 
         ```
                         external_task_sensor = self._get_external_task_sensor(
                            from_task_id, to_task_id
                        )
       ``` 
       for each loop. In this way, Airflow will be repeated to create the sensor in the same DAG --> which will raise the `DuplicateTaskIdFound`.

- Solution:
we add another attribute `sensor_dict` to save the generated `external_task_sensor` for each `to_pipe` with a specific sensor name. In this way, we will prevent Airflow to regenerate the existing sensor.


Tested in airflow tst:https://airflow.datatst.choco.com/dags/core-salesforce/graph. 
