### PR TITLE
Adding sensor to proper dag

### DIFF
--- a/dagger/dag_creator/airflow/dag_creator.py
+++ b/dagger/dag_creator/airflow/dag_creator.py
@@ -65,7 +65,10 @@ class DagCreator(GraphTraverserBase):
         from_pipeline_schedule = self._task_graph.get_node(from_task_id).obj.pipeline.schedule
         to_pipeline_schedule = self._task_graph.get_node(to_task_id).obj.pipeline.schedule
 
+        to_pipe_id = self._task_graph.get_node(to_task_id).obj.pipeline.name
+
         return ExternalTaskSensor(
+            dag=self._dags[to_pipe_id],
             task_id=external_sensor_name,
             external_dag_id=from_pipeline_name,
             external_task_id=from_task_name,


### PR DESCRIPTION
Jira Ticket: [DATA=1500](https://choco.atlassian.net/browse/DATA-1500)

Sensor was not giving slack alert when failed.
Root Cause: When sensor operator was created the dag object was not passed into the operator as a parameter, hence the default arguments (which contains what to do on failure) were also not passed into the sensor operator.

This fix is adding the dag object into the sensor operator on creation time, making sure that all default arguments, like the on_failure_callback function is also passed in.

tested in [tst environment](https://airflow.datatst.choco.com/task?dag_id=core-salesforce&task_id=analytics_engineering-dbt_hourly-dbt_hourly-sensor&execution_date=2022-04-07T23%3A30%3A00%2B00%3A00)