### PR TITLE
Feature/sensor parameters

### DIFF
--- a/dagger/graph/task_graph.py
+++ b/dagger/graph/task_graph.py
@@ -55,7 +55,7 @@ class Node(ABC):
 
 
 class Edge:
-    def __init__(self, follow_external_dependency=False):
+    def __init__(self, follow_external_dependency=None):
         self._follow_external_dependency = follow_external_dependency
 
     @property

--- a/dagger/pipeline/io.py
+++ b/dagger/pipeline/io.py
@@ -19,9 +19,15 @@ class IO(ConfigValidator, ABC):
                 Attribute(
                     attribute_name="follow_external_dependency",
                     required=False,
-                    comment="Weather an external task sensor should be created if this dataset"
-                            "is created in another pipeline. Default is False",
+                    format_help="dictionary or boolean",
+                    comment="External Task Sensor parameters in key value format: https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/sensors/base/index.html"
                 ),
+                # Attribute(
+                #     attribute_name="follow_external_dependency",
+                #     required=False,
+                #     comment="Weather an external task sensor should be created if this dataset"
+                #             "is created in another pipeline. Default is False",
+                # ),
             ]
         )
 
@@ -34,7 +40,17 @@ class IO(ConfigValidator, ABC):
         self._has_dependency = self.parse_attribute("has_dependency")
         if self._has_dependency is None:
             self._has_dependency = True
-        self._follow_external_dependency = self.parse_attribute("follow_external_dependency") or False
+
+        follow_external_dependency = self.parse_attribute("follow_external_dependency")
+        if follow_external_dependency is not None:
+            if isinstance(follow_external_dependency, bool):
+                if follow_external_dependency:
+                    follow_external_dependency = dict()
+                else:
+                    follow_external_dependency = None
+            else:
+                follow_external_dependency = dict(follow_external_dependency)
+        self._follow_external_dependency = follow_external_dependency
 
     def __eq__(self, other):
         return self.alias() == other.alias()

--- a/tests/fixtures/config_finder/root/dags/test_external_sensor/dummy_first.yaml
+++ b/tests/fixtures/config_finder/root/dags/test_external_sensor/dummy_first.yaml
@@ -5,7 +5,8 @@ inputs:                        # format: list | Use dagger init-io cli
     name: redshift_input
     schema: dwh
     table: batch_table
-    follow_external_dependency: True
+    follow_external_dependency:
+      poke_interval: 60
 outputs:                       # format: list | Use dagger init-io cli
   - type: dummy
     name: first_dummy_output


### PR DESCRIPTION
Adding the possibility to change the external task sensor parameters.
Now you can use the default parameters with adding the following to dagger config:
`follow_external_dependency: True`

Or you can pass in any available external task sensor parameter to the same attribute like this:
```yaml
follow_external_dependency:
  mode: standard
  poke_interval: 60
```

