### PR TITLE
Added functionality for DBT seed generation

### DIFF
--- a/dagger/utilities/dbt_config_parser.py
+++ b/dagger/utilities/dbt_config_parser.py
@@ -34,6 +34,22 @@ class DBTConfigParser:
             "s3_data_dir"
         ) or prod_dbt_profile.get("s3_staging_dir")
 
+    def _process_seed_input(self, seed_node: dict) -> dict:
+        """
+        Generates a dummy dagger task for the DBT seed node
+        Args:
+            seed_node: The extracted seed node from the manifest.json file
+
+        Returns:
+            dict: The dummy dagger task for the DBT seed node
+
+        """
+        task = {}
+        task["name"] = seed_node.get("name", "")
+        task["type"] = "dummy"
+
+        return task
+
     def _generate_dagger_dependency(self, node: dict) -> List[Dict]:
         """
         Generates the dagger task based on whether the DBT model node is a staging model or not.

--- a/dagger/utilities/dbt_config_parser.py
+++ b/dagger/utilities/dbt_config_parser.py
@@ -6,9 +6,8 @@ from typing import Tuple, List, Dict
 
 import yaml
 
-ATHENA_TASK_BASE = {"type": "athena"}
+ATHENA_TASK_BASE = {"type": "athena", "follow_external_dependency": True}
 S3_TASK_BASE = {"type": "s3"}
-
 
 
 class DBTConfigParser:

--- a/tests/fixtures/modules/dbt_config_parser_fixtures.py
+++ b/tests/fixtures/modules/dbt_config_parser_fixtures.py
@@ -47,6 +47,7 @@ DBT_MANIFEST_FILE_FIXTURE = {
                 "nodes": [
                     "source.main.core_schema2.table2",
                     "source.main.core_schema2.table3",
+                    "seed.main.seed_buyer_country_overwrite",
                 ],
             },
         },
@@ -145,6 +146,17 @@ EXPECTED_STAGING_NODE_MULTIPLE_DEPENDENCIES = [
         "table": "table3",
         "follow_external_dependency": True,
     },
+    {
+        "type": "dummy",
+        "name": "seed_buyer_country_overwrite",
+    },
+]
+
+EXPECTED_SEED_NODE = [
+    {
+        "type": "dummy",
+        "name": "seed_buyer_country_overwrite",
+    }
 ]
 
 EXPECTED_DAGGER_INPUTS = [
@@ -162,6 +174,7 @@ EXPECTED_DAGGER_INPUTS = [
         "type": "athena",
         "follow_external_dependency": True,
     },
+    {"name": "seed_buyer_country_overwrite", "type": "dummy"},
     {
         "name": "analytics_engineering_model2_athena",
         "schema": "analytics_engineering",

--- a/tests/fixtures/modules/dbt_config_parser_fixtures.py
+++ b/tests/fixtures/modules/dbt_config_parser_fixtures.py
@@ -61,7 +61,44 @@ DBT_MANIFEST_FILE_FIXTURE = {
             "name": "int_model3",
             "schema": "analytics_engineering",
         },
-    }
+        "seed.main.seed_buyer_country_overwrite": {
+            "database": "awsdatacatalog",
+            "schema": "analytics_engineering",
+            "name": "seed_buyer_country_overwrite",
+            "resource_type": "seed",
+            "alias": "seed_buyer_country_overwrite",
+            "tags": ["analytics"],
+            "description": "",
+            "created_at": 1700216177.105391,
+            "depends_on": {"macros": []},
+        },
+    },
+    "sources": {
+        "source.main.core_schema1.table1": {
+            "source_name": "table1",
+            "database": "awsdatacatalog",
+            "schema": "core_schema1",
+            "name": "table1",
+            "tags": ["analytics"],
+            "description": "",
+        },
+        "source.main.core_schema2.table2": {
+            "source_name": "table2",
+            "database": "awsdatacatalog",
+            "schema": "core_schema2",
+            "name": "table2",
+            "tags": ["analytics"],
+            "description": "",
+        },
+        "source.main.core_schema2.table3": {
+            "source_name": "table3",
+            "database": "awsdatacatalog",
+            "schema": "core_schema2",
+            "name": "table3",
+            "tags": ["analytics"],
+            "description": "",
+        },
+    },
 }
 
 DBT_PROFILE_FIXTURE = {
@@ -90,6 +127,7 @@ EXPECTED_STAGING_NODE = [
         "name": "stg_core_schema1__table1",
         "schema": "core_schema1",
         "table": "table1",
+        "follow_external_dependency": True,
     }
 ]
 EXPECTED_STAGING_NODE_MULTIPLE_DEPENDENCIES = [
@@ -98,12 +136,14 @@ EXPECTED_STAGING_NODE_MULTIPLE_DEPENDENCIES = [
         "name": "stg_core_schema2__table2",
         "schema": "core_schema2",
         "table": "table2",
+        "follow_external_dependency": True,
     },
     {
         "type": "athena",
         "name": "stg_core_schema2__table3",
         "schema": "core_schema2",
         "table": "table3",
+        "follow_external_dependency": True,
     },
 ]
 
@@ -113,18 +153,21 @@ EXPECTED_DAGGER_INPUTS = [
         "schema": "core_schema2",
         "table": "table2",
         "type": "athena",
+        "follow_external_dependency": True,
     },
     {
         "name": "stg_core_schema2__table3",
         "schema": "core_schema2",
         "table": "table3",
         "type": "athena",
+        "follow_external_dependency": True,
     },
     {
         "name": "analytics_engineering_model2_athena",
         "schema": "analytics_engineering",
         "table": "model2",
         "type": "athena",
+        "follow_external_dependency": True,
     },
     {
         "bucket": "bucket1-data-lake",
@@ -140,6 +183,7 @@ EXPECTED_DAGGER_OUTPUTS = [
         "schema": "analytics_engineering",
         "table": "fct_supplier_revenue",
         "type": "athena",
+        "follow_external_dependency": True,
     },
     {
         "bucket": "bucket1-data-lake",

--- a/tests/utilities/test_dbt_config_parser.py
+++ b/tests/utilities/test_dbt_config_parser.py
@@ -12,6 +12,7 @@ from tests.fixtures.modules.dbt_config_parser_fixtures import (
     DBT_PROFILE_FIXTURE,
     EXPECTED_STAGING_NODE,
     EXPECTED_STAGING_NODE_MULTIPLE_DEPENDENCIES,
+    EXPECTED_SEED_NODE,
 )
 
 _logger = logging.getLogger("root")
@@ -57,6 +58,12 @@ class TestDBTConfigParser(unittest.TestCase):
                     "model.main.stg_core_schema2__table2"
                 ],
                 EXPECTED_STAGING_NODE_MULTIPLE_DEPENDENCIES,
+            ),
+            (
+                DBT_MANIFEST_FILE_FIXTURE["nodes"][
+                    "seed.main.seed_buyer_country_overwrite"
+                ],
+                EXPECTED_SEED_NODE,
             ),
         ]
         for mock_input, expected_output in test_inputs:


### PR DESCRIPTION
If there is a DBT seed as a dependency to a model, then a dummy task is created for the seed and added as an input to the model that makes use of it.

This PR adds this functionality and also improves the tests