### PR TITLE
Fix/dbt add core sensor to int

### DIFF
--- a/dagger/utilities/dbt_config_parser.py
+++ b/dagger/utilities/dbt_config_parser.py
@@ -152,6 +152,10 @@ class DBTConfigParser:
         elif node.get("config", {}).get("materialized") == "ephemeral":
             task = self._get_dummy_task(node, follow_external_dependency=True)
             dagger_tasks.append(task)
+
+            ephemeral_parent_node_names = node.get("depends_on", {}).get("nodes", [])
+            for node_name in ephemeral_parent_node_names:
+                dagger_tasks += self._generate_dagger_tasks(node_name)
         elif node.get("name").startswith("stg_"):
             dagger_tasks.append(
                 self._get_dummy_task(node, follow_external_dependency=True)

--- a/tests/fixtures/modules/dbt_config_parser_fixtures.py
+++ b/tests/fixtures/modules/dbt_config_parser_fixtures.py
@@ -78,6 +78,10 @@ DBT_MANIFEST_FILE_FIXTURE = {
             "config": {
                 "materialized": "ephemeral",
             },
+            "depends_on": {
+                "macros": [],
+                "nodes": ["model.main.int_model2"],
+            },
         },
         "seed.main.seed_buyer_country_overwrite": {
             "database": "awsdatacatalog",
@@ -105,6 +109,21 @@ DBT_MANIFEST_FILE_FIXTURE = {
                     "model.main.model2",
                     "seed.main.seed_buyer_country_overwrite",
                     "model.main.stg_core_schema2__table2",
+                ],
+            },
+        },
+        "model.main.int_model2": {
+            "name": "int_model2",
+            "unique_id": "model.main.int_model2",
+            "schema": "analytics_engineering",
+            "config": {
+                "materialized": "ephemeral",
+            },
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "seed.main.seed_buyer_country_overwrite",
+                    "model.main.stg_core_schema1__table1",
                 ],
             },
         },
@@ -185,6 +204,20 @@ EXPECTED_MODEL_MULTIPLE_DEPENDENCIES = [
         "follow_external_dependency": True,
     },
     {
+        "type": "dummy",
+        "name": "int_model2",
+        "follow_external_dependency": True,
+    },
+    {
+        "type": "dummy",
+        "name": "seed_buyer_country_overwrite",
+    },
+    {
+        "name": "stg_core_schema1__table1",
+        "type": "dummy",
+        "follow_external_dependency": True,
+    },
+    {
         "type": "athena",
         "name": "analytics_engineering__model2_athena",
         "schema": "analytics_engineering",
@@ -198,10 +231,6 @@ EXPECTED_MODEL_MULTIPLE_DEPENDENCIES = [
         "type": "s3",
     },
     {
-        "type": "dummy",
-        "name": "seed_buyer_country_overwrite",
-    },
-    {
         "name": "stg_core_schema2__table2",
         "type": "dummy",
         "follow_external_dependency": True,
@@ -212,6 +241,20 @@ EXPECTED_EPHEMERAL_NODE = [
     {
         "type": "dummy",
         "name": "int_model3",
+        "follow_external_dependency": True,
+    },
+    {
+        "type": "dummy",
+        "name": "int_model2",
+        "follow_external_dependency": True,
+    },
+    {
+        "type": "dummy",
+        "name": "seed_buyer_country_overwrite",
+    },
+    {
+        "name": "stg_core_schema1__table1",
+        "type": "dummy",
         "follow_external_dependency": True,
     }
 ]
@@ -256,7 +299,17 @@ EXPECTED_DAGGER_INPUTS = [
         "name": "int_model3",
         "follow_external_dependency": True,
     },
+    {
+        "type": "dummy",
+        "name": "int_model2",
+        "follow_external_dependency": True,
+    },
     {"name": "seed_buyer_country_overwrite", "type": "dummy"},
+    {
+        "name": "stg_core_schema1__table1",
+        "type": "dummy",
+        "follow_external_dependency": True,
+    },
 ]
 
 EXPECTED_DBT_STAGING_MODEL_DAGGER_INPUTS = [
@@ -296,5 +349,14 @@ EXPECTED_DBT_STAGING_MODEL_DAGGER_OUTPUTS = [
     {
         "type": "dummy",
         "name": "stg_core_schema2__table2",
+    },
+]
+
+EXPECTED_DBT_INT_MODEL_DAGGER_INPUTS = [
+    {"name": "seed_buyer_country_overwrite", "type": "dummy"},
+    {
+        "name": "stg_core_schema1__table1",
+        "type": "dummy",
+        "follow_external_dependency": True,
     },
 ]

--- a/tests/utilities/test_dbt_config_parser.py
+++ b/tests/utilities/test_dbt_config_parser.py
@@ -17,6 +17,7 @@ from tests.fixtures.modules.dbt_config_parser_fixtures import (
     EXPECTED_DBT_STAGING_MODEL_DAGGER_OUTPUTS,
     EXPECTED_DBT_STAGING_MODEL_DAGGER_INPUTS,
     EXPECTED_MODEL_NODE,
+    EXPECTED_DBT_INT_MODEL_DAGGER_INPUTS
 )
 
 _logger = logging.getLogger("root")
@@ -78,6 +79,7 @@ class TestDBTConfigParser(unittest.TestCase):
                 EXPECTED_MODEL_MULTIPLE_DEPENDENCIES,
             ),
             ("stg_core_schema2__table2", EXPECTED_DBT_STAGING_MODEL_DAGGER_INPUTS),
+            ("int_model2", EXPECTED_DBT_INT_MODEL_DAGGER_INPUTS),
         ]
         for mock_input, expected_output in fixtures:
             result, _ = self._dbt_config_parser.generate_dagger_io(mock_input)


### PR DESCRIPTION
[DATA-1750](https://choco.atlassian.net/browse/DATA-1750)

The changes in this PR make sure to get the parents of an intermediate table and add it as an input to the dbt task config. By doing this, we can make sure that data flows through int models as they are updated in the staging layer of DBT(which is connected to the core layer)


### Test case:

I used the `fct_final_order_transmission` table as an example to generate the task config. For this, the output dbt task config adds the first upstream dependencies of the model until either models in the staging layer are parents and/or a materialized table/view is a parent. For example, below is the entire lineage of the parents of `fct_final_order_transmission`:
![image](https://github.com/chocoapp/dataeng-dagger/assets/16002904/fcf43ced-3ba2-4a64-8402-0b7560183fe2)

The box in red are the inputs that are defined for this model.

[link to dbt docs page](https://airflow.data.choco.com/dbtdocsview/#!/model/model.main.fct_final_order_transmission?g_v=1&g_i=4%2Bfct_final_order_transmission)

and here are the inputs that are generated by the code:
```yaml
- name: int_user__order_preference
  type: dummy
  follow_external_dependency: true
- name: stg_core_chats__chat_user_lookup
  type: dummy
  follow_external_dependency: true
- type: athena
  follow_external_dependency: true
  schema: chats
  table: chat_user_lookup
  name: chats__chat_user_lookup_athena
- name: stg_core_users__user
  type: dummy
  follow_external_dependency: true
- type: athena
  follow_external_dependency: true
  schema: users
  table: user
  name: users__user_athena
- name: stg_core_users__order_preference
  type: dummy
  follow_external_dependency: true
- type: athena
  follow_external_dependency: true
  schema: users
  table: order_preference
  name: users__order_preference_athena
- name: int_crm__final_order_transmission
  type: dummy
  follow_external_dependency: true
- name: stg_core_orders__order_transmissioned
  type: dummy
  follow_external_dependency: true
- type: athena
  follow_external_dependency: true
  schema: orders
  table: order_transmissioned
  name: orders__order_transmissioned_athena
- type: athena
  follow_external_dependency: true
  schema: analytics_engineering
  table: fct_order
  name: analytics_engineering__fct_order_athena
- type: s3
  name: analytics_engineering__fct_order_s3
  bucket: cho${ENV}-data-lake
  path: dwh/analytics_engineering/analytics/fct_order
```



[DATA-1750]: https://choco.atlassian.net/browse/DATA-1750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ