### PR TITLE
Turning split_statements on by default

### DIFF
--- a/dagger/dag_creator/airflow/operators/postgres_operator.py
+++ b/dagger/dag_creator/airflow/operators/postgres_operator.py
@@ -51,6 +51,6 @@ class PostgresOperator(DaggerBaseOperator):
         self.hook = PostgresHook(
             postgres_conn_id=self.postgres_conn_id, schema=self.database
         )
-        self.hook.run(self.sql, self.autocommit, parameters=self.parameters)
+        self.hook.run(self.sql, self.autocommit, parameters=self.parameters, split_statements=True)
         for output in self.hook.conn.notices:
             self.log.info(output)


### PR DESCRIPTION
For the incremental redshift dim load I need to run multiple sql commands in one query, but this is only possible if I enable the split_statment attribute, which is going to actually run all sql statements in the query as a separate sql query.