### PR TITLE
Upgrading some package versions to remove warnings

### DIFF
--- a/reqs/base.txt
+++ b/reqs/base.txt
@@ -1,7 +1,7 @@
 click==8.1.3
-croniter==1.3.8
+croniter==2.0.2
 envyaml==1.10.211231
 mergedeep==1.3.4
 slack==0.0.2
 slackclient==2.9.4
-tenacity==8.2.0
+tenacity==8.2.3


### PR DESCRIPTION
Need to upgrade these packages to be able to install airflow and dagger together in airflow-dags repo