### PR TITLE
feat: rename profile_name to target_name

### DIFF
--- a/dagger/dag_creator/airflow/operator_creators/dbt_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/dbt_creator.py
@@ -12,7 +12,7 @@ class DbtCreator(BatchCreator):
 
         self._project_dir = task.project_dir
         self._profile_dir = task.profile_dir
-        self._profile_name = task.profile_name
+        self._target_name = task.target_name
         self._select = task.select
         self._dbt_command = task.dbt_command
 
@@ -20,7 +20,7 @@ class DbtCreator(BatchCreator):
         command = [self._task.executable_prefix, self._task.executable]
         command.append(f"--project_dir={self._project_dir}")
         command.append(f"--profiles_dir={self._profile_dir}")
-        command.append(f"--profile_name={self._profile_name}")
+        command.append(f"--target_name={self._target_name}")
         command.append(f"--dbt_command={self._dbt_command}")
         if self._select:
             command.append(f"--select={self._select}")

--- a/dagger/pipeline/tasks/dbt_task.py
+++ b/dagger/pipeline/tasks/dbt_task.py
@@ -20,7 +20,7 @@ class DbtTask(BatchTask):
                     comment="Which directory to look in for the profiles.yml file",
                 ),
                 Attribute(
-                    attribute_name="profile_name",
+                    attribute_name="target_name",
                     required=False,
                     parent_fields=["task_parameters"],
                     comment="Which target to load for the given profile "
@@ -45,7 +45,7 @@ class DbtTask(BatchTask):
 
         self._project_dir = self.parse_attribute("project_dir")
         self._profile_dir = self.parse_attribute("profile_dir")
-        self._profile_name = self.parse_attribute("profile_name") or "default"
+        self._target_name = self.parse_attribute("target_name") or "default"
         self._select = self.parse_attribute("select")
         self._dbt_command = self.parse_attribute("dbt_command")
 
@@ -58,8 +58,8 @@ class DbtTask(BatchTask):
         return self._profile_dir
 
     @property
-    def profile_name(self):
-        return self._profile_name
+    def target_name(self):
+        return self._target_name
 
     @property
     def select(self):

--- a/dockers/airflow/airflow.cfg
+++ b/dockers/airflow/airflow.cfg
@@ -434,7 +434,7 @@ backend =
 # The backend_kwargs param is loaded into a dictionary and passed to __init__ of secrets backend class.
 # See documentation for the secrets backend you are using. JSON is expected.
 # Example for AWS Systems Manager ParameterStore:
-# ``{{"connections_prefix": "/airflow/connections", "profile_name": "default"}}``
+# ``{{"connections_prefix": "/airflow/connections", "target_name": "default"}}``
 backend_kwargs =
 
 [cli]


### PR DESCRIPTION
Rename the `profile_name` param in dbt task parameters to `target_name` 
(According to the [dbt documentation](https://docs.getdbt.com/docs/core/connect-data-platform/profiles.yml) what we were naming `profile_name`  is actually `target_name` )