### PR TITLE
Switching to official batch operator

### DIFF
--- a/dagger/dag_creator/airflow/operator_creators/batch_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/batch_creator.py
@@ -1,5 +1,9 @@
+from pathlib import Path
+from datetime import timedelta
+
 from dagger.dag_creator.airflow.operator_creator import OperatorCreator
 from dagger.dag_creator.airflow.operators.awsbatch_operator import AWSBatchOperator
+from dagger import conf
 
 
 class BatchCreator(OperatorCreator):
@@ -7,6 +11,20 @@ class BatchCreator(OperatorCreator):
 
     def __init__(self, task, dag):
         super().__init__(task, dag)
+
+    @staticmethod
+    def _validate_job_name(job_name, absolute_job_name):
+        if not absolute_job_name and not job_name:
+            raise Exception("Both job_name and absolute_job_name cannot be null")
+
+        if absolute_job_name is not None:
+            return absolute_job_name
+
+        job_path = Path(conf.DAGS_DIR) / job_name.replace("-", "/")
+        assert (
+            job_path.is_dir()
+        ), f"Job name `{job_name}`, points to a non-existing folder `{job_path}`"
+        return job_name
 
     def _generate_command(self):
         command = [self._task.executable_prefix, self._task.executable]
@@ -21,16 +39,16 @@ class BatchCreator(OperatorCreator):
         overrides = self._task.overrides
         overrides.update({"command": self._generate_command()})
 
+        job_name = self._validate_job_name(self._task.job_name, self._task.absolute_job_name)
         batch_op = AWSBatchOperator(
             dag=self._dag,
             task_id=self._task.name,
-            job_name=self._task.job_name,
-            absolute_job_name=self._task.absolute_job_name,
+            job_name=self._task.name,
+            job_definition=job_name,
             region_name=self._task.region_name,
-            cluster_name=self._task.cluster_name,
             job_queue=self._task.job_queue,
-            overrides=overrides,
+            container_overrides=overrides,
+            awslogs_enabled=True,
             **kwargs,
         )
-
         return batch_op

--- a/dagger/dag_creator/airflow/operator_creators/spark_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/spark_creator.py
@@ -113,7 +113,7 @@ class SparkCreator(OperatorCreator):
                 job_name=job_name,
                 region_name=self._task.region_name,
                 job_queue=self._task.job_queue,
-                overrides=overrides,
+                container_overrides=overrides,
                 **kwargs,
             )
         elif self._task.spark_engine == "glue":

--- a/dagger/dag_creator/airflow/operators/awsbatch_operator.py
+++ b/dagger/dag_creator/airflow/operators/awsbatch_operator.py
@@ -8,7 +8,7 @@ from airflow.providers.amazon.aws.links.batch import (
 from airflow.providers.amazon.aws.links.logs import CloudWatchEventsLink
 
 
-class AWSBatchOperator(AWSBatchOperator):
+class AWSBatchOperator(BatchOperator):
     @staticmethod
     def _format_cloudwatch_link(awslogs_region: str, awslogs_group: str, awslogs_stream_name: str):
         return f"https://{awslogs_region}.console.aws.amazon.com/cloudwatch/home?region={awslogs_region}#logEventViewer:group={awslogs_group};stream={awslogs_stream_name}"


### PR DESCRIPTION
[DATA-1804](https://choco.atlassian.net/browse/DATA-1804)

The newest version of the official aws batch operator collects all logs from cloudwatch, however there is a bug inside and because of that it cannot log the link to the cloudwatch logs, which is an important peace of information.
1. Switching to official Batch operator
2. Create a custom batch operator inhereted from the official one, which ovverwrites the monitor_job function and prints the proper link to cloudwatch logs in the logs.

[DATA-1804]: https://choco.atlassian.net/browse/DATA-1804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ