### PR TITLE
fix: _get_model_data_location in DatabricksDBTConfigParser

### DIFF
--- a/dagger/utilities/dbt_config_parser.py
+++ b/dagger/utilities/dbt_config_parser.py
@@ -305,7 +305,7 @@ class DatabricksDBTConfigParser(DBTConfigParser):
         Gets the S3 path of the dbt model relative to the data bucket.
         """
         location_root = node.get("config", {}).get("location_root")
-        location = join(location_root, schema, model_name)
+        location = join(location_root, model_name)
         split = location.split("//")[1].split("/")
         bucket_name, data_path = split[0], "/".join(split[1:])
 

--- a/tests/fixtures/modules/dbt_config_parser_fixtures_databricks.py
+++ b/tests/fixtures/modules/dbt_config_parser_fixtures_databricks.py
@@ -22,7 +22,7 @@ DATABRICKS_DBT_MANIFEST_FILE_FIXTURE = {
             "unique_id": "model.main.model1",
             "resource_type": "model",
             "config": {
-                "location_root": "s3://chodata-data-lake/analytics_warehouse/data/marts",
+                "location_root": "s3://chodata-data-lake/analytics_warehouse/data/marts/analytics_engineering",
                 "materialized": "incremental",
                 "incremental_strategy": "insert_overwrite",
             },
@@ -30,7 +30,7 @@ DATABRICKS_DBT_MANIFEST_FILE_FIXTURE = {
             "tags": ["daily"],
             "unrendered_config": {
                 "materialized": "incremental",
-                "location_root": "s3://chodata-data-lake/analytics_warehouse/data/marts",
+                "location_root": "s3://chodata-data-lake/analytics_warehouse/data/marts/analytics_engineering",
                 "incremental_strategy": "insert_overwrite",
                 "partitioned_by": ["year", "month", "day", "dt"],
                 "tags": ["daily"],
@@ -90,7 +90,7 @@ DATABRICKS_DBT_MANIFEST_FILE_FIXTURE = {
             "unique_id": "model.main.model2",
             "resource_type": "model",
             "config": {
-                "location_root": "s3://chodata-data-lake/analytics_warehouse/data/marts",
+                "location_root": "s3://chodata-data-lake/analytics_warehouse/data/marts/analytics_engineering",
                 "materialized": "table",
             },
             "depends_on": {"macros": [], "nodes": []},
@@ -103,7 +103,7 @@ DATABRICKS_DBT_MANIFEST_FILE_FIXTURE = {
             "resource_type": "model",
             "config": {
                 "materialized": "ephemeral",
-                "location_root": "s3://chodata-data-lake/analytics_warehouse/data/intermediate",
+                "location_root": "s3://chodata-data-lake/analytics_warehouse/data/intermediate/analytics_engineering",
             },
             "depends_on": {
                 "macros": [],
@@ -128,7 +128,7 @@ DATABRICKS_DBT_MANIFEST_FILE_FIXTURE = {
             "schema": "analytics_engineering",
             "unique_id": "model.main.model3",
             "config": {
-                "location_root": "s3://chodata-data-lake/analytics_warehouse/data/marts",
+                "location_root": "s3://chodata-data-lake/analytics_warehouse/data/marts/analytics_engineering",
             },
             "depends_on": {
                 "macros": [],
@@ -147,7 +147,7 @@ DATABRICKS_DBT_MANIFEST_FILE_FIXTURE = {
             "schema": "analytics_engineering",
             "config": {
                 "materialized": "ephemeral",
-                "location_root": "s3://chodata-data-lake/analytics_warehouse/data/intermediate",
+                "location_root": "s3://chodata-data-lake/analytics_warehouse/data/intermediate/analytics_engineering",
             },
             "depends_on": {
                 "macros": [],


### PR DESCRIPTION
fix: _get_model_data_location in DatabricksDBTConfigParser #38

the `location_root` already has the `schema` in the path