### PR TITLE
DATA-1996: adjust the dbt config parser so that view/ephemeral staging layer doesnt need a task

### DIFF
--- a/dagger/utilities/dbt_config_parser.py
+++ b/dagger/utilities/dbt_config_parser.py
@@ -161,21 +161,19 @@ class DBTConfigParser(ABC):
                 node, follow_external_dependency=True
             )
             dagger_tasks.append(table_task)
-        elif node.get("config", {}).get("materialized") == "ephemeral" or ((node.get("name").startswith("stg_") or "preparation" in node.get(
-            "schema", ""
-        )) and node.get("config", {}).get("materialized") != "table"):
+        elif node.get("config", {}).get("materialized") == "ephemeral" or (
+            (
+                node.get("name").startswith("stg_")
+                or "preparation" in node.get("schema", "")
+            )
+            and node.get("config", {}).get("materialized") != "table"
+        ):
             task = self._get_dummy_task(node, follow_external_dependency=True)
             dagger_tasks.append(task)
 
             ephemeral_parent_node_names = node.get("depends_on", {}).get("nodes", [])
             for node_name in ephemeral_parent_node_names:
                 dagger_tasks += self._generate_dagger_tasks(node_name)
-        elif (node.get("name").startswith("stg_") or "preparation" in node.get(
-            "schema", ""
-        ) and node.get("config", {}).get("materialized") == "table"):
-            dagger_tasks.append(
-                self._get_dummy_task(node, follow_external_dependency=True)
-            )
         else:
             table_task = self._get_table_task(node, follow_external_dependency=True)
             s3_task = self._get_s3_task(node)

--- a/dagger/utilities/dbt_config_parser.py
+++ b/dagger/utilities/dbt_config_parser.py
@@ -161,16 +161,18 @@ class DBTConfigParser(ABC):
                 node, follow_external_dependency=True
             )
             dagger_tasks.append(table_task)
-        elif node.get("config", {}).get("materialized") == "ephemeral":
+        elif node.get("config", {}).get("materialized") == "ephemeral" or ((node.get("name").startswith("stg_") or "preparation" in node.get(
+            "schema", ""
+        )) and node.get("config", {}).get("materialized") != "table"):
             task = self._get_dummy_task(node, follow_external_dependency=True)
             dagger_tasks.append(task)
 
             ephemeral_parent_node_names = node.get("depends_on", {}).get("nodes", [])
             for node_name in ephemeral_parent_node_names:
                 dagger_tasks += self._generate_dagger_tasks(node_name)
-        elif node.get("name").startswith("stg_") or "preparation" in node.get(
+        elif (node.get("name").startswith("stg_") or "preparation" in node.get(
             "schema", ""
-        ):
+        ) and node.get("config", {}).get("materialized") == "table"):
             dagger_tasks.append(
                 self._get_dummy_task(node, follow_external_dependency=True)
             )

--- a/tests/fixtures/modules/dbt_config_parser_fixtures_athena.py
+++ b/tests/fixtures/modules/dbt_config_parser_fixtures_athena.py
@@ -59,6 +59,7 @@ DBT_MANIFEST_FILE_FIXTURE = {
             "name": "stg_core_schema1__table1",
             "config": {
                 "materialized": "table",
+                "external_location": "s3://bucket1-data-lake/path2/stg_core_schema1__table1",
             },
             "depends_on": {
                 "macros": [],
@@ -184,9 +185,17 @@ DBT_MANIFEST_FILE_FIXTURE = {
 
 EXPECTED_STAGING_NODE = [
     {
-        "name": "stg_core_schema1__table1",
-        "type": "dummy",
+        "name": "analytics_engineering__stg_core_schema1__table1_athena",
+        "type": "athena",
+        "table": "stg_core_schema1__table1",
+        "schema": "analytics_engineering",
         "follow_external_dependency": True,
+    },
+    {
+        "type": "s3",
+        "name": "s3_stg_core_schema1__table1",
+        "bucket": "bucket1-data-lake",
+        "path": "path2/stg_core_schema1__table1",
     },
 ]
 
@@ -213,9 +222,17 @@ EXPECTED_MODEL_MULTIPLE_DEPENDENCIES = [
         "name": "seed_buyer_country_overwrite",
     },
     {
-        "name": "stg_core_schema1__table1",
-        "type": "dummy",
+        "name": "analytics_engineering__stg_core_schema1__table1_athena",
+        "type": "athena",
+        "table": "stg_core_schema1__table1",
+        "schema": "analytics_engineering",
         "follow_external_dependency": True,
+    },
+    {
+        "type": "s3",
+        "name": "s3_stg_core_schema1__table1",
+        "bucket": "bucket1-data-lake",
+        "path": "path2/stg_core_schema1__table1",
     },
     {
         "type": "athena",
@@ -267,10 +284,18 @@ EXPECTED_EPHEMERAL_NODE = [
         "name": "seed_buyer_country_overwrite",
     },
     {
-        "name": "stg_core_schema1__table1",
-        "type": "dummy",
+        "name": "analytics_engineering__stg_core_schema1__table1_athena",
+        "type": "athena",
+        "table": "stg_core_schema1__table1",
+        "schema": "analytics_engineering",
         "follow_external_dependency": True,
-    }
+    },
+    {
+        "type": "s3",
+        "name": "s3_stg_core_schema1__table1",
+        "bucket": "bucket1-data-lake",
+        "path": "path2/stg_core_schema1__table1",
+    },
 ]
 
 EXPECTED_MODEL_NODE = [
@@ -334,10 +359,18 @@ EXPECTED_DAGGER_INPUTS = [
         "follow_external_dependency": True,
     },
     {
-        "name": "stg_core_schema1__table1",
-        "type": "dummy",
+        "name": "analytics_engineering__stg_core_schema1__table1_athena",
+        "type": "athena",
+        "table": "stg_core_schema1__table1",
+        "schema": "analytics_engineering",
         "follow_external_dependency": True,
-    }
+    },
+    {
+        "type": "s3",
+        "name": "s3_stg_core_schema1__table1",
+        "bucket": "bucket1-data-lake",
+        "path": "path2/stg_core_schema1__table1",
+    },
 ]
 
 EXPECTED_DBT_STAGING_MODEL_DAGGER_INPUTS = [
@@ -383,8 +416,16 @@ EXPECTED_DBT_STAGING_MODEL_DAGGER_OUTPUTS = [
 EXPECTED_DBT_INT_MODEL_DAGGER_INPUTS = [
     {"name": "seed_buyer_country_overwrite", "type": "dummy"},
     {
-        "name": "stg_core_schema1__table1",
-        "type": "dummy",
+        "name": "analytics_engineering__stg_core_schema1__table1_athena",
+        "type": "athena",
+        "table": "stg_core_schema1__table1",
+        "schema": "analytics_engineering",
         "follow_external_dependency": True,
+    },
+    {
+        "type": "s3",
+        "name": "s3_stg_core_schema1__table1",
+        "bucket": "bucket1-data-lake",
+        "path": "path2/stg_core_schema1__table1",
     },
 ]

--- a/tests/fixtures/modules/dbt_config_parser_fixtures_athena.py
+++ b/tests/fixtures/modules/dbt_config_parser_fixtures_athena.py
@@ -201,8 +201,10 @@ EXPECTED_STAGING_NODE = [
 
 EXPECTED_SEED_NODE = [
     {
-        "type": "dummy",
-        "name": "seed_buyer_country_overwrite",
+        "type": "athena",
+        "schema": "analytics_engineering",
+        "table": "seed_buyer_country_overwrite",
+        "name": "analytics_engineering__seed_buyer_country_overwrite_athena",
     }
 ]
 
@@ -210,16 +212,16 @@ EXPECTED_MODEL_MULTIPLE_DEPENDENCIES = [
     {
         "type": "dummy",
         "name": "int_model3",
-        "follow_external_dependency": True,
     },
     {
         "type": "dummy",
         "name": "int_model2",
-        "follow_external_dependency": True,
     },
     {
-        "type": "dummy",
-        "name": "seed_buyer_country_overwrite",
+        "type": "athena",
+        "schema": "analytics_engineering",
+        "table": "seed_buyer_country_overwrite",
+        "name": "analytics_engineering__seed_buyer_country_overwrite_athena",
     },
     {
         "name": "analytics_engineering__stg_core_schema1__table1_athena",
@@ -248,9 +250,10 @@ EXPECTED_MODEL_MULTIPLE_DEPENDENCIES = [
         "type": "s3",
     },
     {
-        "name": "stg_core_schema2__table2",
-        "type": "dummy",
-        "follow_external_dependency": True,
+        "type": "athena",
+        "schema": "analytics_engineering",
+        "table": "stg_core_schema2__table2",
+        "name": "analytics_engineering__stg_core_schema2__table2_athena",
     },
     {
         "type": "athena",
@@ -272,16 +275,16 @@ EXPECTED_EPHEMERAL_NODE = [
     {
         "type": "dummy",
         "name": "int_model3",
-        "follow_external_dependency": True,
     },
     {
         "type": "dummy",
         "name": "int_model2",
-        "follow_external_dependency": True,
     },
     {
-        "type": "dummy",
-        "name": "seed_buyer_country_overwrite",
+        "type": "athena",
+        "schema": "analytics_engineering",
+        "table": "seed_buyer_country_overwrite",
+        "name": "analytics_engineering__seed_buyer_country_overwrite_athena",
     },
     {
         "name": "analytics_engineering__stg_core_schema1__table1_athena",
@@ -316,9 +319,10 @@ EXPECTED_MODEL_NODE = [
 
 EXPECTED_DAGGER_INPUTS = [
     {
-        "name": "stg_core_schema2__table2",
-        "type": "dummy",
-        "follow_external_dependency": True,
+        "type": "athena",
+        "schema": "analytics_engineering",
+        "table": "stg_core_schema2__table2",
+        "name": "analytics_engineering__stg_core_schema2__table2_athena",
     },
     {
         "type": "athena",
@@ -334,7 +338,12 @@ EXPECTED_DAGGER_INPUTS = [
         "table": "table3",
         "follow_external_dependency": True,
     },
-    {"name": "seed_buyer_country_overwrite", "type": "dummy"},
+    {
+        "type": "athena",
+        "schema": "analytics_engineering",
+        "table": "seed_buyer_country_overwrite",
+        "name": "analytics_engineering__seed_buyer_country_overwrite_athena",
+    },
     {
         "name": "analytics_engineering__model2_athena",
         "schema": "analytics_engineering",
@@ -351,12 +360,10 @@ EXPECTED_DAGGER_INPUTS = [
     {
         "type": "dummy",
         "name": "int_model3",
-        "follow_external_dependency": True,
     },
     {
         "type": "dummy",
         "name": "int_model2",
-        "follow_external_dependency": True,
     },
     {
         "name": "analytics_engineering__stg_core_schema1__table1_athena",
@@ -388,7 +395,12 @@ EXPECTED_DBT_STAGING_MODEL_DAGGER_INPUTS = [
         "table": "table3",
         "type": "athena",
     },
-    {"name": "seed_buyer_country_overwrite", "type": "dummy"},
+    {
+        "type": "athena",
+        "schema": "analytics_engineering",
+        "table": "seed_buyer_country_overwrite",
+        "name": "analytics_engineering__seed_buyer_country_overwrite_athena",
+    }
 ]
 
 EXPECTED_DAGGER_OUTPUTS = [
@@ -408,13 +420,26 @@ EXPECTED_DAGGER_OUTPUTS = [
 
 EXPECTED_DBT_STAGING_MODEL_DAGGER_OUTPUTS = [
     {
-        "type": "dummy",
-        "name": "stg_core_schema2__table2",
+        "name": "analytics_engineering__stg_core_schema1__table1_athena",
+        "type": "athena",
+        "table": "stg_core_schema1__table1",
+        "schema": "analytics_engineering",
+    },
+    {
+        "type": "s3",
+        "name": "output_s3_path",
+        "bucket": "bucket1-data-lake",
+        "path": "path2/stg_core_schema1__table1",
     },
 ]
 
 EXPECTED_DBT_INT_MODEL_DAGGER_INPUTS = [
-    {"name": "seed_buyer_country_overwrite", "type": "dummy"},
+    {
+        "type": "athena",
+        "schema": "analytics_engineering",
+        "table": "seed_buyer_country_overwrite",
+        "name": "analytics_engineering__seed_buyer_country_overwrite_athena",
+    },
     {
         "name": "analytics_engineering__stg_core_schema1__table1_athena",
         "type": "athena",

--- a/tests/fixtures/modules/dbt_config_parser_fixtures_athena.py
+++ b/tests/fixtures/modules/dbt_config_parser_fixtures_athena.py
@@ -58,7 +58,7 @@ DBT_MANIFEST_FILE_FIXTURE = {
             "unique_id": "model.main.stg_core_schema1__table1",
             "name": "stg_core_schema1__table1",
             "config": {
-                "materialized": "view",
+                "materialized": "table",
             },
             "depends_on": {
                 "macros": [],
@@ -235,6 +235,20 @@ EXPECTED_MODEL_MULTIPLE_DEPENDENCIES = [
         "type": "dummy",
         "follow_external_dependency": True,
     },
+    {
+        "type": "athena",
+        "name": "core_schema2__table2_athena",
+        "schema": "core_schema2",
+        "table": "table2",
+        "follow_external_dependency": True,
+    },
+    {
+        "type": "athena",
+        "name": "core_schema2__table3_athena",
+        "schema": "core_schema2",
+        "table": "table3",
+        "follow_external_dependency": True,
+    },
 ]
 
 EXPECTED_EPHEMERAL_NODE = [
@@ -256,7 +270,7 @@ EXPECTED_EPHEMERAL_NODE = [
         "name": "stg_core_schema1__table1",
         "type": "dummy",
         "follow_external_dependency": True,
-    },
+    }
 ]
 
 EXPECTED_MODEL_NODE = [
@@ -282,6 +296,21 @@ EXPECTED_DAGGER_INPUTS = [
         "follow_external_dependency": True,
     },
     {
+        "type": "athena",
+        "name": "core_schema2__table2_athena",
+        "schema": "core_schema2",
+        "table": "table2",
+        "follow_external_dependency": True,
+    },
+    {
+        "type": "athena",
+        "name": "core_schema2__table3_athena",
+        "schema": "core_schema2",
+        "table": "table3",
+        "follow_external_dependency": True,
+    },
+    {"name": "seed_buyer_country_overwrite", "type": "dummy"},
+    {
         "name": "analytics_engineering__model2_athena",
         "schema": "analytics_engineering",
         "table": "model2",
@@ -304,12 +333,11 @@ EXPECTED_DAGGER_INPUTS = [
         "name": "int_model2",
         "follow_external_dependency": True,
     },
-    {"name": "seed_buyer_country_overwrite", "type": "dummy"},
     {
         "name": "stg_core_schema1__table1",
         "type": "dummy",
         "follow_external_dependency": True,
-    },
+    }
 ]
 
 EXPECTED_DBT_STAGING_MODEL_DAGGER_INPUTS = [

--- a/tests/fixtures/modules/dbt_config_parser_fixtures_databricks.py
+++ b/tests/fixtures/modules/dbt_config_parser_fixtures_databricks.py
@@ -57,7 +57,7 @@ DATABRICKS_DBT_MANIFEST_FILE_FIXTURE = {
             "resource_type": "model",
             "config": {
                 "location_root": "s3://chodata-data-lake/analytics_warehouse/data/preparation",
-                "materialized": "view",
+                "materialized": "table",
             },
             "depends_on": {
                 "macros": [],
@@ -246,6 +246,20 @@ DATABRICKS_EXPECTED_MODEL_MULTIPLE_DEPENDENCIES = [
         "type": "dummy",
         "follow_external_dependency": True,
     },
+    {
+        "type": "athena",
+        "name": "core_schema2__table2_athena",
+        "schema": "core_schema2",
+        "table": "table2",
+        "follow_external_dependency": True,
+    },
+    {
+        "type": "athena",
+        "name": "core_schema2__table3_athena",
+        "schema": "core_schema2",
+        "table": "table3",
+        "follow_external_dependency": True,
+    },
 ]
 
 DATABRICKS_EXPECTED_EPHEMERAL_NODE = [
@@ -294,6 +308,21 @@ DATABRICKS_EXPECTED_DAGGER_INPUTS = [
         "follow_external_dependency": True,
     },
     {
+        "type": "athena",
+        "name": "core_schema2__table2_athena",
+        "schema": "core_schema2",
+        "table": "table2",
+        "follow_external_dependency": True,
+    },
+    {
+        "type": "athena",
+        "name": "core_schema2__table3_athena",
+        "schema": "core_schema2",
+        "table": "table3",
+        "follow_external_dependency": True,
+    },
+    {"name": "seed_buyer_country_overwrite", "type": "dummy"},
+    {
         "name": "marts__analytics_engineering__model2_databricks",
         "catalog": "marts",
         "schema": "analytics_engineering",
@@ -317,7 +346,6 @@ DATABRICKS_EXPECTED_DAGGER_INPUTS = [
         "name": "int_model2",
         "follow_external_dependency": True,
     },
-    {"name": "seed_buyer_country_overwrite", "type": "dummy"},
     {
         "name": "stg_core_schema1__table1",
         "type": "dummy",

--- a/tests/fixtures/modules/dbt_config_parser_fixtures_databricks.py
+++ b/tests/fixtures/modules/dbt_config_parser_fixtures_databricks.py
@@ -112,7 +112,7 @@ DATABRICKS_DBT_MANIFEST_FILE_FIXTURE = {
         },
         "seed.main.seed_buyer_country_overwrite": {
             "database": "hive_metastore",
-            "schema": "datastg_preparation",
+            "schema": "data_preparation",
             "name": "seed_buyer_country_overwrite",
             "unique_id": "seed.main.seed_buyer_country_overwrite",
             "resource_type": "seed",
@@ -211,8 +211,11 @@ DATABRICKS_EXPECTED_STAGING_NODE = [
 
 DATABRICKS_EXPECTED_SEED_NODE = [
     {
-        "type": "dummy",
-        "name": "seed_buyer_country_overwrite",
+        "type": "databricks",
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "seed_buyer_country_overwrite",
+        "name": "hive_metastore__data_preparation__seed_buyer_country_overwrite_databricks",
     }
 ]
 
@@ -220,24 +223,25 @@ DATABRICKS_EXPECTED_MODEL_MULTIPLE_DEPENDENCIES = [
     {
         "type": "dummy",
         "name": "int_model3",
-        "follow_external_dependency": True,
     },
     {
         "type": "dummy",
         "name": "int_model2",
-        "follow_external_dependency": True,
-    },
-    {
-        "type": "dummy",
-        "name": "seed_buyer_country_overwrite",
     },
     {
         "type": "databricks",
-        "follow_external_dependency": True,
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "seed_buyer_country_overwrite",
+        "name": "hive_metastore__data_preparation__seed_buyer_country_overwrite_databricks",
+    },
+    {
+        "type": "databricks",
         "catalog": "hive_metastore",
         "schema": "data_preparation",
         "table": "stg_core_schema1__table1",
         "name": "hive_metastore__data_preparation__stg_core_schema1__table1_databricks",
+        "follow_external_dependency": True,
     },
     {
         "type": "s3",
@@ -260,9 +264,11 @@ DATABRICKS_EXPECTED_MODEL_MULTIPLE_DEPENDENCIES = [
         "type": "s3",
     },
     {
-        "name": "stg_core_schema2__table2",
-        "type": "dummy",
-        "follow_external_dependency": True,
+        "type": "databricks",
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "stg_core_schema2__table2",
+        "name": "hive_metastore__data_preparation__stg_core_schema2__table2_databricks",
     },
     {
         "type": "athena",
@@ -284,16 +290,17 @@ DATABRICKS_EXPECTED_EPHEMERAL_NODE = [
     {
         "type": "dummy",
         "name": "int_model3",
-        "follow_external_dependency": True,
     },
     {
         "type": "dummy",
         "name": "int_model2",
-        "follow_external_dependency": True,
     },
     {
-        "type": "dummy",
-        "name": "seed_buyer_country_overwrite",
+        "type": "databricks",
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "seed_buyer_country_overwrite",
+        "name": "hive_metastore__data_preparation__seed_buyer_country_overwrite_databricks",
     },
     {
         "type": "databricks",
@@ -330,9 +337,11 @@ DATABRICKS_EXPECTED_MODEL_NODE = [
 
 DATABRICKS_EXPECTED_DAGGER_INPUTS = [
     {
-        "name": "stg_core_schema2__table2",
-        "type": "dummy",
-        "follow_external_dependency": True,
+        "type": "databricks",
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "stg_core_schema2__table2",
+        "name": "hive_metastore__data_preparation__stg_core_schema2__table2_databricks",
     },
     {
         "type": "athena",
@@ -348,7 +357,13 @@ DATABRICKS_EXPECTED_DAGGER_INPUTS = [
         "table": "table3",
         "follow_external_dependency": True,
     },
-    {"name": "seed_buyer_country_overwrite", "type": "dummy"},
+    {
+        "type": "databricks",
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "seed_buyer_country_overwrite",
+        "name": "hive_metastore__data_preparation__seed_buyer_country_overwrite_databricks",
+    },
     {
         "name": "marts__analytics_engineering__model2_databricks",
         "catalog": "marts",
@@ -366,12 +381,10 @@ DATABRICKS_EXPECTED_DAGGER_INPUTS = [
     {
         "type": "dummy",
         "name": "int_model3",
-        "follow_external_dependency": True,
     },
     {
         "type": "dummy",
         "name": "int_model2",
-        "follow_external_dependency": True,
     },
     {
         "type": "databricks",
@@ -404,11 +417,23 @@ DATABRICKS_EXPECTED_DBT_STAGING_MODEL_DAGGER_INPUTS = [
         "table": "table3",
         "type": "athena",
     },
-    {"name": "seed_buyer_country_overwrite", "type": "dummy"},
+    {
+        "type": "databricks",
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "seed_buyer_country_overwrite",
+        "name": "hive_metastore__data_preparation__seed_buyer_country_overwrite_databricks",
+    },
 ]
 
 DATABRICKS_EXPECTED_DBT_INT_MODEL_DAGGER_INPUTS = [
-    {"name": "seed_buyer_country_overwrite", "type": "dummy"},
+    {
+        "type": "databricks",
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "seed_buyer_country_overwrite",
+        "name": "hive_metastore__data_preparation__seed_buyer_country_overwrite_databricks",
+    },
     {
         "type": "databricks",
         "follow_external_dependency": True,
@@ -449,7 +474,22 @@ DATABRICKS_EXPECTED_DAGGER_OUTPUTS = [
 
 DATABRICKS_EXPECTED_DBT_STAGING_MODEL_DAGGER_OUTPUTS = [
     {
-        "type": "dummy",
-        "name": "stg_core_schema2__table2",
+        "type": "databricks",
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "stg_core_schema1__table1",
+        "name": "hive_metastore__data_preparation__stg_core_schema1__table1_databricks",
     },
+    {
+        "type": "s3",
+        "name": "output_s3_path",
+        "bucket": "chodata-data-lake",
+        "path": "analytics_warehouse/data/preparation/stg_core_schema1__table1",
+    },
+    {
+        'type': 'athena',
+        'schema': 'data_preparation',
+        'table': 'stg_core_schema1__table1',
+        'name': 'data_preparation__stg_core_schema1__table1_athena'
+    }
 ]

--- a/tests/fixtures/modules/dbt_config_parser_fixtures_databricks.py
+++ b/tests/fixtures/modules/dbt_config_parser_fixtures_databricks.py
@@ -194,9 +194,18 @@ DATABRICKS_DBT_MANIFEST_FILE_FIXTURE = {
 
 DATABRICKS_EXPECTED_STAGING_NODE = [
     {
-        "name": "stg_core_schema1__table1",
-        "type": "dummy",
+        "type": "databricks",
         "follow_external_dependency": True,
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "stg_core_schema1__table1",
+        "name": "hive_metastore__data_preparation__stg_core_schema1__table1_databricks",
+    },
+    {
+        "type": "s3",
+        "name": "s3_stg_core_schema1__table1",
+        "bucket": "chodata-data-lake",
+        "path": "analytics_warehouse/data/preparation/stg_core_schema1__table1",
     },
 ]
 
@@ -223,9 +232,18 @@ DATABRICKS_EXPECTED_MODEL_MULTIPLE_DEPENDENCIES = [
         "name": "seed_buyer_country_overwrite",
     },
     {
-        "name": "stg_core_schema1__table1",
-        "type": "dummy",
+        "type": "databricks",
         "follow_external_dependency": True,
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "stg_core_schema1__table1",
+        "name": "hive_metastore__data_preparation__stg_core_schema1__table1_databricks",
+    },
+    {
+        "type": "s3",
+        "name": "s3_stg_core_schema1__table1",
+        "bucket": "chodata-data-lake",
+        "path": "analytics_warehouse/data/preparation/stg_core_schema1__table1",
     },
     {
         "type": "databricks",
@@ -278,9 +296,18 @@ DATABRICKS_EXPECTED_EPHEMERAL_NODE = [
         "name": "seed_buyer_country_overwrite",
     },
     {
-        "name": "stg_core_schema1__table1",
-        "type": "dummy",
+        "type": "databricks",
         "follow_external_dependency": True,
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "stg_core_schema1__table1",
+        "name": "hive_metastore__data_preparation__stg_core_schema1__table1_databricks",
+    },
+    {
+        "type": "s3",
+        "name": "s3_stg_core_schema1__table1",
+        "bucket": "chodata-data-lake",
+        "path": "analytics_warehouse/data/preparation/stg_core_schema1__table1",
     },
 ]
 
@@ -347,9 +374,18 @@ DATABRICKS_EXPECTED_DAGGER_INPUTS = [
         "follow_external_dependency": True,
     },
     {
-        "name": "stg_core_schema1__table1",
-        "type": "dummy",
+        "type": "databricks",
         "follow_external_dependency": True,
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "stg_core_schema1__table1",
+        "name": "hive_metastore__data_preparation__stg_core_schema1__table1_databricks",
+    },
+    {
+        "type": "s3",
+        "name": "s3_stg_core_schema1__table1",
+        "bucket": "chodata-data-lake",
+        "path": "analytics_warehouse/data/preparation/stg_core_schema1__table1",
     },
 ]
 
@@ -374,9 +410,18 @@ DATABRICKS_EXPECTED_DBT_STAGING_MODEL_DAGGER_INPUTS = [
 DATABRICKS_EXPECTED_DBT_INT_MODEL_DAGGER_INPUTS = [
     {"name": "seed_buyer_country_overwrite", "type": "dummy"},
     {
-        "name": "stg_core_schema1__table1",
-        "type": "dummy",
+        "type": "databricks",
         "follow_external_dependency": True,
+        "catalog": "hive_metastore",
+        "schema": "data_preparation",
+        "table": "stg_core_schema1__table1",
+        "name": "hive_metastore__data_preparation__stg_core_schema1__table1_databricks",
+    },
+    {
+        "type": "s3",
+        "name": "s3_stg_core_schema1__table1",
+        "bucket": "chodata-data-lake",
+        "path": "analytics_warehouse/data/preparation/stg_core_schema1__table1",
     },
 ]
 

--- a/tests/utilities/test_dbt_config_parser.py
+++ b/tests/utilities/test_dbt_config_parser.py
@@ -50,10 +50,6 @@ class TestAthenaDBTConfigParser(unittest.TestCase):
     def test_generate_dagger_tasks(self):
         test_inputs = [
             (
-                "model.main.stg_core_schema1__table1",
-                EXPECTED_STAGING_NODE,
-            ),
-            (
                 "seed.main.seed_buyer_country_overwrite",
                 EXPECTED_SEED_NODE,
             ),
@@ -159,7 +155,6 @@ class TestDatabricksDBTConfigParser(unittest.TestCase):
         ]
         for mock_input, expected_output in fixtures:
             result, _ = self._dbt_config_parser.generate_dagger_io(mock_input)
-
             self.assertListEqual(result, expected_output)
 
     def test_generate_io_outputs(self):

--- a/tests/utilities/test_dbt_config_parser.py
+++ b/tests/utilities/test_dbt_config_parser.py
@@ -78,13 +78,14 @@ class TestAthenaDBTConfigParser(unittest.TestCase):
         ]
         for mock_input, expected_output in fixtures:
             result, _ = self._dbt_config_parser.generate_dagger_io(mock_input)
-
+            print(f"result: {result}")
+            print(f"expected_output: {expected_output}")
             self.assertListEqual(result, expected_output)
 
     def test_generate_io_outputs(self):
         fixtures = [
             ("model1", EXPECTED_DAGGER_OUTPUTS),
-            ("stg_core_schema2__table2", EXPECTED_DBT_STAGING_MODEL_DAGGER_OUTPUTS),
+            ("stg_core_schema1__table1", EXPECTED_DBT_STAGING_MODEL_DAGGER_OUTPUTS),
         ]
         for mock_input, expected_output in fixtures:
             _, result = self._dbt_config_parser.generate_dagger_io(mock_input)
@@ -161,11 +162,10 @@ class TestDatabricksDBTConfigParser(unittest.TestCase):
         fixtures = [
             ("model1", DATABRICKS_EXPECTED_DAGGER_OUTPUTS),
             (
-                "stg_core_schema2__table2",
+                "stg_core_schema1__table1",
                 DATABRICKS_EXPECTED_DBT_STAGING_MODEL_DAGGER_OUTPUTS,
             ),
         ]
         for mock_input, expected_output in fixtures:
             _, result = self._dbt_config_parser.generate_dagger_io(mock_input)
-
             self.assertListEqual(result, expected_output)


### PR DESCRIPTION
Adjust the dbt config parser so that:

- If the node is a DBT source, an Athena table task is generated.
- If the node is an ephemeral model, a dummy task is generated, and tasks for its dependent nodes are recursively generated.
- If the node is a staging model (preparation model) and not materialized as a table, a table task is generated along with tasks for its dependent nodes.
- For other nodes, a table task is generated. If the node is materialized as a table, an additional S3 task is also generated.


Tested in [airflow-staging](https://airflow.datastg.choco.com/dags/analytics_engineering-dbt_hourly/grid?dag_run_id=scheduled__2024-06-15T00%3A45%3A00%2B00%3A00&task_id=dim_supplier_choco_ai_setup_rs_loader&tab=logs)
example:
<img width="943" alt="Screenshot 2024-06-18 at 09 40 14" src="https://github.com/chocoapp/dataeng-dagger/assets/50731691/96b33fd6-6811-4b81-92cb-4d7d24bf13ea">

