### PR TITLE
Feature/data 2002 generalise jinja params

### DIFF
--- a/dagger/cli/module.py
+++ b/dagger/cli/module.py
@@ -1,17 +1,34 @@
 import click
 from dagger.utilities.module import Module
 from dagger.utils import Printer
+import json
 
+
+def parse_key_value(ctx, param, value):
+    #print('YYY', value)
+    if not value:
+        return {}
+    key_value_dict = {}
+    for pair in value:
+        try:
+            key, val_file_path = pair.split('=', 1)
+            #print('YYY', key, val_file_path, pair)
+            val = json.load(open(val_file_path))
+            key_value_dict[key] = val
+        except ValueError:
+            raise click.BadParameter(f"Key-value pair '{pair}' is not in the format key=value")
+    return key_value_dict
 
 @click.command()
 @click.option("--config_file", "-c", help="Path to module config file")
 @click.option("--target_dir", "-t", help="Path to directory to generate the task configs to")
-def generate_tasks(config_file: str, target_dir: str) -> None:
+@click.option("--jinja_parameters", "-j", callback=parse_key_value, multiple=True, default=None, help="Path to jinja parameters json file in the format: <jinja_variable_name>=<path to json file>")
+def generate_tasks(config_file: str, target_dir: str, jinja_parameters: dict) -> None:
     """
     Generating tasks for a module based on config
     """
 
-    module = Module(config_file, target_dir)
+    module = Module(config_file, target_dir, jinja_parameters)
     module.generate_task_configs()
 
     Printer.print_success("Tasks are successfully generated")

--- a/dagger/pipeline/task.py
+++ b/dagger/pipeline/task.py
@@ -37,6 +37,12 @@ class Task(ConfigValidator):
                 ),
                 Attribute(attribute_name="pool", required=False),
                 Attribute(
+                    attribute_name="task_group",
+                    required=False,
+                    format_help=str,
+                    comment="Task group name",
+                ),
+                Attribute(
                     attribute_name="timeout_in_seconds",
                     required=False,
                     format_help="int",
@@ -73,6 +79,7 @@ class Task(ConfigValidator):
         self._outputs = []
         self._pool = self.parse_attribute("pool") or self.default_pool
         self._timeout_in_seconds = self.parse_attribute("timeout_in_seconds")
+        self._task_group = self.parse_attribute("task_group")
         self.process_inputs(config["inputs"])
         self.process_outputs(config["outputs"])
 
@@ -136,6 +143,10 @@ class Task(ConfigValidator):
     @property
     def timeout_in_seconds(self):
         return self._timeout_in_seconds
+
+    @property
+    def task_group(self):
+        return self._task_group
 
     def add_input(self, task_input: IO):
         _logger.info("Adding input: %s to task: %s", task_input.name, self._name)

--- a/dagger/utilities/module.py
+++ b/dagger/utilities/module.py
@@ -14,7 +14,7 @@ _logger = logging.getLogger("root")
 
 
 class Module:
-    def __init__(self, path_to_config, target_dir):
+    def __init__(self, path_to_config, target_dir, jinja_parameters):
         self._directory = path.dirname(path_to_config)
         self._target_dir = target_dir or "./"
         self._path_to_config = path_to_config
@@ -29,6 +29,7 @@ class Module:
         self._branches_to_generate = config["branches_to_generate"]
         self._override_parameters = config.get("override_parameters", {})
         self._default_parameters = config.get("default_parameters", {})
+        self._jinja_parameters = jinja_parameters
 
     @staticmethod
     def read_yaml(yaml_str):
@@ -76,6 +77,7 @@ class Module:
             template_parameters.update(self._default_parameters or {})
             template_parameters.update(attrs)
             template_parameters['branch_name'] = branch_name
+            template_parameters.update(self._jinja_parameters)
 
             dbt_manifest = None
             if "dbt" in self._tasks.keys():


### PR DESCRIPTION
[DATA-2002](https://choco.atlassian.net/browse/DATA-2002)

1. Adding new parameter to the module config generator, so now we can pass any number of json files to the generator, which will be accessible from the jinja template as parameters.
2. Enabling using [airflow's task group feature](https://www.astronomer.io/docs/learn/task-groups) which helps visually grouping airflow tasks on the airflow UI. This will make our test graph a little bit easier to navigate especially after we move the tasks into their respective marts.