### PR TITLE
Feature/data 2025 reverse etl operator

### DIFF
--- a/dagger/conf.py
+++ b/dagger/conf.py
@@ -104,3 +104,9 @@ DEFAULT_ALERT = alert_config.get('default_alert', {"type": "slack", "channel": "
 plugin_config = config.get('plugin', None) or {}
 PLUGIN_DIRS = [os.path.join(AIRFLOW_HOME, path) for path in plugin_config.get('paths', [])]
 logging.info(f"All Python classes will be loaded as plugins from the following directories: {PLUGIN_DIRS}")
+
+# ReverseETL parameters
+reverse_etl_config = config.get('reverse_etl', None) or {}
+REVERSE_ETL_DEFAULT_JOB_NAME = reverse_etl_config.get('default_job_name', None)
+REVERSE_ETL_DEFAULT_EXECUTABLE_PREFIX = reverse_etl_config.get('default_executable_prefix', None)
+REVERSE_ETL_DEFAULT_EXECUTABLE = reverse_etl_config.get('default_executable', None)

--- a/dagger/dag_creator/airflow/operator_creators/reverse_etl_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/reverse_etl_creator.py
@@ -26,6 +26,7 @@ class ReverseEtlCreator(BatchCreator):
         self._from_time = task.from_time
         self._days_to_live = task.days_to_live
         self._output_type = task.output_type
+        self._region_name = task.region_name
 
     def _generate_command(self):
         command = BatchCreator._generate_command(self)
@@ -53,6 +54,8 @@ class ReverseEtlCreator(BatchCreator):
             command.append(f"--from_time={self._from_time}")
         if self._days_to_live:
             command.append(f"--days_to_live={self._days_to_live}")
+        if self._region_name:
+            command.append(f"--region_name={self._region_name}")
 
         return command
 

--- a/dagger/dag_creator/airflow/operator_creators/reverse_etl_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/reverse_etl_creator.py
@@ -1,0 +1,55 @@
+import base64
+
+from dagger.dag_creator.airflow.operator_creators.batch_creator import BatchCreator
+import json
+
+
+class ReverseEtlCreator(BatchCreator):
+    ref_name = "reverse_etl"
+
+    def __init__(self, task, dag):
+        super().__init__(task, dag)
+
+        self._assume_role_arn = task.assume_role_arn
+        self._num_threads = task.num_threads
+        self._batch_size = task.batch_size
+        self._absolute_job_name = task.absolute_job_name
+        self._primary_id_column = task.primary_id_column
+        self._secondary_id_column = task.secondary_id_column
+        self._custom_id_column = task.custom_id_column
+        self._model_name = task.model_name
+        self._project_name = task.project_name
+        self._is_deleted_column = task.is_deleted_column
+        self._hash_column = task.hash_column
+        self._updated_at_column = task.updated_at_column
+        self._from_time = task.from_time
+        self._days_to_live = task.days_to_live
+
+    def _generate_command(self):
+        command = [self._task.executable_prefix, self._task.executable]
+
+
+        command.append(f"--num_threads={self._num_threads}")
+        command.append(f"--batch_size={self._batch_size}")
+        command.append(f"--primary_id_column={self._primary_id_column}")
+        command.append(f"--model_name={self._model_name}")
+        command.append(f"--project_name={self._project_name}")
+
+        if self._assume_role_arn:
+            command.append(f"--assume_role_arn={self._assume_role_arn}")
+        if self._secondary_id_column:
+            command.append(f"--secondary_id_column={self._secondary_id_column}")
+        if self._custom_id_column:
+            command.append(f"--custom_id_column={self._custom_id_column}")
+        if self._is_deleted_column:
+            command.append(f"--is_deleted_column={self._is_deleted_column}")
+        if self._hash_column:
+            command.append(f"--hash_column={self._hash_column}")
+        if self._updated_at_column:
+            command.append(f"--updated_at_column={self._updated_at_column}")
+        if self._from_time:
+            command.append(f"--from_time={self._from_time}")
+        if self._days_to_live:
+            command.append(f"--days_to_live={self._days_to_live}")
+
+        return command

--- a/dagger/dag_creator/airflow/operator_creators/reverse_etl_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/reverse_etl_creator.py
@@ -25,6 +25,7 @@ class ReverseEtlCreator(BatchCreator):
         self._updated_at_column = task.updated_at_column
         self._from_time = task.from_time
         self._days_to_live = task.days_to_live
+        self._output_type = task.output_type
 
     def _generate_command(self):
         command = BatchCreator._generate_command(self)
@@ -34,6 +35,7 @@ class ReverseEtlCreator(BatchCreator):
         command.append(f"--primary_id_column={self._primary_id_column}")
         command.append(f"--model_name={self._model_name}")
         command.append(f"--project_name={self._project_name}")
+        command.append(f"--output_type={self._output_type}")
 
         if self._assume_role_arn:
             command.append(f"--assume_role_arn={self._assume_role_arn}")

--- a/dagger/dag_creator/airflow/operator_factory.py
+++ b/dagger/dag_creator/airflow/operator_factory.py
@@ -10,6 +10,7 @@ from dagger.dag_creator.airflow.operator_creators import (
     redshift_load_creator,
     redshift_transform_creator,
     redshift_unload_creator,
+    reverse_etl_creator,
     spark_creator,
     sqoop_creator,
 )

--- a/dagger/dag_creator/airflow/operators/reverse_etl_batch.py
+++ b/dagger/dag_creator/airflow/operators/reverse_etl_batch.py
@@ -1,0 +1,8 @@
+from dagger.dag_creator.airflow.operators.awsbatch_operator import AWSBatchOperator
+
+class ReverseEtlBatchOperator(AWSBatchOperator):
+    custom_operator_name = 'ReverseETL'
+    ui_color = "#f0ede4"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(args, kwargs)

--- a/dagger/dag_creator/airflow/operators/reverse_etl_batch.py
+++ b/dagger/dag_creator/airflow/operators/reverse_etl_batch.py
@@ -3,6 +3,3 @@ from dagger.dag_creator.airflow.operators.awsbatch_operator import AWSBatchOpera
 class ReverseEtlBatchOperator(AWSBatchOperator):
     custom_operator_name = 'ReverseETL'
     ui_color = "#f0ede4"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(args, kwargs)

--- a/dagger/dagger_config.yaml
+++ b/dagger/dagger_config.yaml
@@ -62,3 +62,8 @@ alert:
 plugin:
 #  paths:
 #    - plugins
+
+reverse_etl:
+#  default_job_name:
+#  default_executable_prefix:
+#  default_executable:

--- a/dagger/pipeline/io.py
+++ b/dagger/pipeline/io.py
@@ -63,6 +63,10 @@ class IO(ConfigValidator, ABC):
     def name(self):
         return self._name
 
+    @name.setter
+    def name(self, value):
+        self._name = value
+
     @property
     def has_dependency(self):
         return self._has_dependency

--- a/dagger/pipeline/io_factory.py
+++ b/dagger/pipeline/io_factory.py
@@ -7,7 +7,9 @@ from dagger.pipeline.ios import (
     gdrive_io,
     redshift_io,
     s3_io,
-    databricks_io
+    databricks_io,
+    dynamo_io,
+    sns_io,
 )
 from dagger.utilities.classes import get_deep_obj_subclasses
 

--- a/dagger/pipeline/ios/dynamo_io.py
+++ b/dagger/pipeline/ios/dynamo_io.py
@@ -1,0 +1,60 @@
+from dagger.pipeline.io import IO
+from dagger.utilities.config_validator import Attribute
+
+
+class DynamoIO(IO):
+    ref_name = "dynamo"
+
+    @classmethod
+    def init_attributes(cls, orig_cls):
+        cls.add_config_attributes(
+            [
+                Attribute(
+                    attribute_name="account_id",
+                    required=False,
+                    comment="Only needed for cross account dynamo tables"
+                ),
+                Attribute(
+                    attribute_name="region",
+                    required=False,
+                    comment="Only needed for cross region dynamo tables"
+                ),
+                Attribute(
+                    attribute_name="table",
+                    comment="The name of the dynamo table"
+                ),
+            ]
+        )
+
+    def __init__(self, io_config, config_location):
+        super().__init__(io_config, config_location)
+
+        self._account_id = self.parse_attribute("account_id")
+        self._region = self.parse_attribute("region")
+        self._table = self.parse_attribute("table")
+
+    def alias(self):
+        return f"dynamo://{self._account_id or ''}/{self._region or ''}/{self._table}"
+
+    @property
+    def rendered_name(self):
+        if not self._account_id and not self._region:
+            return self._table
+        else:
+            return ":".join([self._account_id or '', self._region or '', self._table])
+
+    @property
+    def airflow_name(self):
+        return f"dynamo-{'-'.join([name_part for name_part in [self._account_id, self._region, self._table] if name_part])}"
+
+    @property
+    def account_id(self):
+        return self._account_id
+
+    @property
+    def region(self):
+        return self._region
+
+    @property
+    def table(self):
+        return self._table

--- a/dagger/pipeline/ios/dynamo_io.py
+++ b/dagger/pipeline/ios/dynamo_io.py
@@ -10,12 +10,7 @@ class DynamoIO(IO):
         cls.add_config_attributes(
             [
                 Attribute(
-                    attribute_name="account_id",
-                    required=False,
-                    comment="Only needed for cross account dynamo tables"
-                ),
-                Attribute(
-                    attribute_name="region",
+                    attribute_name="region_name",
                     required=False,
                     comment="Only needed for cross region dynamo tables"
                 ),
@@ -29,31 +24,23 @@ class DynamoIO(IO):
     def __init__(self, io_config, config_location):
         super().__init__(io_config, config_location)
 
-        self._account_id = self.parse_attribute("account_id")
-        self._region = self.parse_attribute("region")
+        self._region_name = self.parse_attribute("region_name")
         self._table = self.parse_attribute("table")
 
     def alias(self):
-        return f"dynamo://{self._account_id or ''}/{self._region or ''}/{self._table}"
+        return f"dynamo://{self._region_name or ''}/{self._table}"
 
     @property
     def rendered_name(self):
-        if not self._account_id and not self._region:
-            return self._table
-        else:
-            return ":".join([self._account_id or '', self._region or '', self._table])
+        return self._table
 
     @property
     def airflow_name(self):
-        return f"dynamo-{'-'.join([name_part for name_part in [self._account_id, self._region, self._table] if name_part])}"
+        return f"dynamo-{'-'.join([name_part for name_part in [self._region_name, self._table] if name_part])}"
 
     @property
-    def account_id(self):
-        return self._account_id
-
-    @property
-    def region(self):
-        return self._region
+    def region_name(self):
+        return self._region_name
 
     @property
     def table(self):

--- a/dagger/pipeline/ios/sns_io.py
+++ b/dagger/pipeline/ios/sns_io.py
@@ -1,0 +1,60 @@
+from dagger.pipeline.io import IO
+from dagger.utilities.config_validator import Attribute
+
+
+class SnsIO(IO):
+    ref_name = "sns"
+
+    @classmethod
+    def init_attributes(cls, orig_cls):
+        cls.add_config_attributes(
+            [
+                Attribute(
+                    attribute_name="account_id",
+                    required=False,
+                    comment="Only needed for cross account dynamo tables"
+                ),
+                Attribute(
+                    attribute_name="region",
+                    required=False,
+                    comment="Only needed for cross region dynamo tables"
+                ),
+                Attribute(
+                    attribute_name="sns_topic",
+                    comment="The name of the sns topic"
+                ),
+            ]
+        )
+
+    def __init__(self, io_config, config_location):
+        super().__init__(io_config, config_location)
+
+        self._account_id = self.parse_attribute("account_id")
+        self._region = self.parse_attribute("region")
+        self._sns_topic = self.parse_attribute("sns_topic")
+
+    def alias(self):
+        return f"dynamo://{self._account_id or ''}/{self._region or ''}/{self._sns_topic}"
+
+    @property
+    def rendered_name(self):
+        if not self._account_id and not self._region:
+            return self._sns_topic
+        else:
+            return ":".join([self._account_id or '', self._region or '', self._sns_topic])
+
+    @property
+    def airflow_name(self):
+        return f"dynamo-{'-'.join([name_part for name_part in [self._account_id, self._region, self._sns_topic] if name_part])}"
+
+    @property
+    def account_id(self):
+        return self._account_id
+
+    @property
+    def region(self):
+        return self._region
+
+    @property
+    def sns_topic(self):
+        return self._sns_topic

--- a/dagger/pipeline/ios/sns_io.py
+++ b/dagger/pipeline/ios/sns_io.py
@@ -33,7 +33,7 @@ class SnsIO(IO):
         self._sns_topic = self.parse_attribute("sns_topic")
 
     def alias(self):
-        return f"dynamo://{self._region_name or ''}/{self._sns_topic}"
+        return f"sns://{self._region_name or ''}/{self._sns_topic}"
 
     @property
     def rendered_name(self):
@@ -41,7 +41,7 @@ class SnsIO(IO):
 
     @property
     def airflow_name(self):
-        return f"dynamo-{'-'.join([name_part for name_part in [self._region_name, self._sns_topic] if name_part])}"
+        return f"sns-{'-'.join([name_part for name_part in [self._region_name, self._sns_topic] if name_part])}"
 
     @property
     def region_name(self):

--- a/dagger/pipeline/ios/sns_io.py
+++ b/dagger/pipeline/ios/sns_io.py
@@ -15,7 +15,7 @@ class SnsIO(IO):
                     comment="Only needed for cross account dynamo tables"
                 ),
                 Attribute(
-                    attribute_name="region",
+                    attribute_name="region_name",
                     required=False,
                     comment="Only needed for cross region dynamo tables"
                 ),
@@ -29,31 +29,23 @@ class SnsIO(IO):
     def __init__(self, io_config, config_location):
         super().__init__(io_config, config_location)
 
-        self._account_id = self.parse_attribute("account_id")
-        self._region = self.parse_attribute("region")
+        self._region_name = self.parse_attribute("region_name")
         self._sns_topic = self.parse_attribute("sns_topic")
 
     def alias(self):
-        return f"dynamo://{self._account_id or ''}/{self._region or ''}/{self._sns_topic}"
+        return f"dynamo://{self._region_name or ''}/{self._sns_topic}"
 
     @property
     def rendered_name(self):
-        if not self._account_id and not self._region:
-            return self._sns_topic
-        else:
-            return ":".join([self._account_id or '', self._region or '', self._sns_topic])
+        return self._sns_topic
 
     @property
     def airflow_name(self):
-        return f"dynamo-{'-'.join([name_part for name_part in [self._account_id, self._region, self._sns_topic] if name_part])}"
+        return f"dynamo-{'-'.join([name_part for name_part in [self._region_name, self._sns_topic] if name_part])}"
 
     @property
-    def account_id(self):
-        return self._account_id
-
-    @property
-    def region(self):
-        return self._region
+    def region_name(self):
+        return self._region_name
 
     @property
     def sns_topic(self):

--- a/dagger/pipeline/task.py
+++ b/dagger/pipeline/task.py
@@ -39,7 +39,7 @@ class Task(ConfigValidator):
                 Attribute(
                     attribute_name="task_group",
                     required=False,
-                    format_help=str,
+                    format_help="str",
                     comment="Task group name",
                 ),
                 Attribute(

--- a/dagger/pipeline/task_factory.py
+++ b/dagger/pipeline/task_factory.py
@@ -9,6 +9,7 @@ from dagger.pipeline.tasks import (
     redshift_load_task,
     redshift_transform_task,
     redshift_unload_task,
+    reverse_etl_task,
     spark_task,
     sqoop_task,
 )

--- a/dagger/pipeline/tasks/reverse_etl_task.py
+++ b/dagger/pipeline/tasks/reverse_etl_task.py
@@ -1,15 +1,9 @@
 from dagger.pipeline.tasks.batch_task import BatchTask
 from dagger.utilities.config_validator import Attribute
+from dagger import conf
 
 class ReverseEtlTask(BatchTask):
     ref_name = "reverse_etl"
-
-    DEFAULT_EXECUTABLE_PREFIX = "python"
-    DEFAULT_EXECUTABLE = "reverse_etl.py"
-    DEFAULT_NUM_THREADS = 4
-    DEFAULT_BATCH_SIZE = 10000
-    DEFAULT_JOB_NAME = "common_batch_jobs-reverse_etl"
-    DEFAULT_PROJECT_NAME = "feature_store"
 
     @classmethod
     def init_attributes(cls, orig_cls):
@@ -78,9 +72,8 @@ class ReverseEtlTask(BatchTask):
                     attribute_name="project_name",
                     parent_fields=["task_parameters"],
                     validator=str,
-                    required=False,
-                    comment="The name of the project. This is going to be a column on the target table. By default it is"
-                            " set to feature_store",
+                    required=True,
+                    comment="The name of the project. This is going to be a column on the target table.",
                 ),
                 Attribute(
                     attribute_name="is_deleted_column",
@@ -130,18 +123,18 @@ class ReverseEtlTask(BatchTask):
     def __init__(self, name, pipeline_name, pipeline, job_config):
         super().__init__(name, pipeline_name, pipeline, job_config)
 
-        self._executable = self.executable or self.DEFAULT_EXECUTABLE
-        self._executable_prefix = self.executable_prefix or self.DEFAULT_EXECUTABLE_PREFIX
+        self._executable = self.executable or conf.REVERSE_ETL_DEFAULT_EXECUTABLE
+        self._executable_prefix = self.executable_prefix or conf.REVERSE_ETL_DEFAULT_EXECUTABLE_PREFIX
 
         self._assume_role_arn = self.parse_attribute("assume_role_arn")
-        self._num_threads = self.parse_attribute("num_threads") or self.DEFAULT_NUM_THREADS
-        self._batch_size = self.parse_attribute("batch_size") or self.DEFAULT_BATCH_SIZE
-        self._absolute_job_name = self._absolute_job_name or self.DEFAULT_JOB_NAME
+        self._num_threads = self.parse_attribute("num_threads")
+        self._batch_size = self.parse_attribute("batch_size")
+        self._absolute_job_name = self._absolute_job_name or conf.REVERSE_ETL_DEFAULT_JOB_NAME
         self._primary_id_column = self.parse_attribute("primary_id_column")
         self._secondary_id_column = self.parse_attribute("secondary_id_column")
         self._custom_id_column = self.parse_attribute("custom_id_column")
         self._model_name = self.parse_attribute("model_name")
-        self._project_name = self.parse_attribute("project_name") or self.DEFAULT_PROJECT_NAME
+        self._project_name = self.parse_attribute("project_name")
         self._is_deleted_column = self.parse_attribute("is_deleted_column")
         self._hash_column = self.parse_attribute("hash_column")
         self._updated_at_column = self.parse_attribute("updated_at_column")

--- a/dagger/pipeline/tasks/reverse_etl_task.py
+++ b/dagger/pipeline/tasks/reverse_etl_task.py
@@ -31,14 +31,12 @@ class ReverseEtlTask(BatchTask):
                     attribute_name="num_threads",
                     parent_fields=["task_parameters"],
                     required=False,
-                    validator=int,
                     comment="The number of threads to use for the job",
                 ),
                 Attribute(
                     attribute_name="batch_size",
                     parent_fields=["task_parameters"],
                     required=False,
-                    validator=int,
                     comment="The number of rows to fetch in each batch",
                 ),
                 Attribute(
@@ -125,8 +123,8 @@ class ReverseEtlTask(BatchTask):
     def __init__(self, name, pipeline_name, pipeline, job_config):
         super().__init__(name, pipeline_name, pipeline, job_config)
 
-        self.executable = self.executable or "reverse_etl.py"
-        self.executable_prefix = self.executable_prefix or "python"
+        self._executable = self.executable or "reverse_etl.py"
+        self._executable_prefix = self.executable_prefix or "python"
 
         self._assume_role_arn = self.parse_attribute("assume_role_arn")
         self._num_threads = self.parse_attribute("num_threads") or 4
@@ -158,7 +156,7 @@ class ReverseEtlTask(BatchTask):
     def num_threads(self):
         return self._num_threads
 
-    @@property
+    @property
     def batch_size(self):
         return self._batch_size
 

--- a/dagger/pipeline/tasks/reverse_etl_task.py
+++ b/dagger/pipeline/tasks/reverse_etl_task.py
@@ -4,6 +4,13 @@ from dagger.utilities.config_validator import Attribute
 class ReverseEtlTask(BatchTask):
     ref_name = "reverse_etl"
 
+    DEFAULT_EXECUTABLE_PREFIX = "python"
+    DEFAULT_EXECUTABLE = "reverse_etl.py"
+    DEFAULT_NUM_THREADS = 4
+    DEFAULT_BATCH_SIZE = 10000
+    DEFAULT_JOB_NAME = "common_batch_jobs/reverse_etl"
+    DEFAULT_PROJECT_NAME = "feature_store"
+
     @classmethod
     def init_attributes(cls, orig_cls):
         cls.add_config_attributes(
@@ -123,18 +130,18 @@ class ReverseEtlTask(BatchTask):
     def __init__(self, name, pipeline_name, pipeline, job_config):
         super().__init__(name, pipeline_name, pipeline, job_config)
 
-        self._executable = self.executable or "reverse_etl.py"
-        self._executable_prefix = self.executable_prefix or "python"
+        self._executable = self.executable or self.DEFAULT_EXECUTABLE
+        self._executable_prefix = self.executable_prefix or self.DEFAULT_EXECUTABLE_PREFIX
 
         self._assume_role_arn = self.parse_attribute("assume_role_arn")
-        self._num_threads = self.parse_attribute("num_threads") or 4
-        self._batch_size = self.parse_attribute("batch_size") or 10000
-        self._absolute_job_name = self._absolute_job_name or "common_batch_jobs/reverse_etl"
+        self._num_threads = self.parse_attribute("num_threads") or self.DEFAULT_NUM_THREADS
+        self._batch_size = self.parse_attribute("batch_size") or self.DEFAULT_BATCH_SIZE
+        self._absolute_job_name = self._absolute_job_name or self.DEFAULT_JOB_NAME
         self._primary_id_column = self.parse_attribute("primary_id_column")
         self._secondary_id_column = self.parse_attribute("secondary_id_column")
         self._custom_id_column = self.parse_attribute("custom_id_column")
         self._model_name = self.parse_attribute("model_name")
-        self._project_name = self.parse_attribute("project_name") or "feature_store"
+        self._project_name = self.parse_attribute("project_name") or self.DEFAULT_PROJECT_NAME
         self._is_deleted_column = self.parse_attribute("is_deleted_column")
         self._hash_column = self.parse_attribute("hash_column")
         self._updated_at_column = self.parse_attribute("updated_at_column")

--- a/dagger/pipeline/tasks/reverse_etl_task.py
+++ b/dagger/pipeline/tasks/reverse_etl_task.py
@@ -148,6 +148,29 @@ class ReverseEtlTask(BatchTask):
             if not self._from_time:
                 raise ValueError("from_time is required when hash_column or updated_at_column is provided")
 
+        # Making sure the input table name is set as it is expected in the reverse etl job
+        input_index = self._get_io_index(self._inputs)
+        self._inputs[input_index].name = "input_table_name"
+
+        # Making sure the output name is set as it is expected in the reverse etl job
+        output_index = self._get_io_index(self._outputs)
+        self._outputs[output_index].name = "output_name"
+
+        # Extracting the output type from the output definition
+        self._output_type = self._outputs[output_index].ref_name
+        if not self._output_type:
+            raise ValueError("ReverseEtlTask must have an output")
+
+    @staticmethod
+    def _get_io_index(ios):
+        if len([io for io in ios if io.ref_name != "dummy"]) > 1:
+            raise ValueError("ReverseEtlTask can only have one input or output")
+
+        for i, io in enumerate(ios):
+            if io.ref_name != "dummy":
+                return i
+
+
     @property
     def assume_role_arn(self):
         return self._assume_role_arn
@@ -199,3 +222,7 @@ class ReverseEtlTask(BatchTask):
     @property
     def days_to_live(self):
         return self._days_to_live
+
+    @property
+    def output_type(self):
+        return self._output_type

--- a/dagger/pipeline/tasks/reverse_etl_task.py
+++ b/dagger/pipeline/tasks/reverse_etl_task.py
@@ -149,33 +149,40 @@ class ReverseEtlTask(BatchTask):
         self._days_to_live = self.parse_attribute("days_to_live")
 
         if self._hash_column and self._updated_at_column:
-            raise ValueError("hash_column and updated_at_column are mutually exclusive")
+            raise ValueError(f"ReverseETLTask: {self._name} hash_column and updated_at_column are mutually exclusive")
 
         if self._hash_column or self._updated_at_column:
             if not self._from_time:
-                raise ValueError("from_time is required when hash_column or updated_at_column is provided")
+                raise ValueError(f"ReverseETLTask: {self._name} from_time is required when hash_column or updated_at_column is provided")
 
         # Making sure the input table name is set as it is expected in the reverse etl job
         input_index = self._get_io_index(self._inputs)
+        print('XXX', self._inputs, input_index)
+        if input_index is None:
+            raise ValueError(f"ReverseEtlTask: {self._name} must have an input")
         self._inputs[input_index].name = "input_table_name"
 
         # Making sure the output name is set as it is expected in the reverse etl job
         output_index = self._get_io_index(self._outputs)
+        if output_index is None:
+            raise ValueError(f"ReverseEtlTask: {self._name} must have an output")
         self._outputs[output_index].name = "output_name"
 
         # Extracting the output type from the output definition
         self._output_type = self._outputs[output_index].ref_name
-        if not self._output_type:
-            raise ValueError("ReverseEtlTask must have an output")
 
-    @staticmethod
-    def _get_io_index(ios):
+        # Extracting the outputs region name from the output definition
+        self._region_name = self._outputs[output_index].region_name
+
+
+    def _get_io_index(self, ios):
         if len([io for io in ios if io.ref_name != "dummy"]) > 1:
-            raise ValueError("ReverseEtlTask can only have one input or output")
+            raise ValueError(f"ReverseEtlTask: {self._name} can only have one input or output")
 
         for i, io in enumerate(ios):
             if io.ref_name != "dummy":
                 return i
+        return None
 
 
     @property
@@ -233,3 +240,7 @@ class ReverseEtlTask(BatchTask):
     @property
     def output_type(self):
         return self._output_type
+
+    @property
+    def region_name(self):
+        return self._region_name

--- a/dagger/pipeline/tasks/reverse_etl_task.py
+++ b/dagger/pipeline/tasks/reverse_etl_task.py
@@ -1,0 +1,203 @@
+from dagger.pipeline.tasks.batch_task import BatchTask
+from dagger.utilities.config_validator import Attribute
+
+class ReverseEtlTask(BatchTask):
+    ref_name = "reverse_etl"
+
+    @classmethod
+    def init_attributes(cls, orig_cls):
+        cls.add_config_attributes(
+            [
+                Attribute(
+                    attribute_name="executable_prefix",
+                    required=False,
+                    parent_fields=["task_parameters"],
+                    comment="E.g.: python",
+                ),
+                Attribute(
+                    attribute_name="executable",
+                    required=False,
+                    parent_fields=["task_parameters"],
+                    comment="E.g.: my_code.py",
+                ),
+                Attribute(
+                    attribute_name="assume_role_arn",
+                    parent_fields=["task_parameters"],
+                    required = False,
+                    validator=str,
+                    comment="The ARN of the role to assume before running the job",
+                ),
+                Attribute(
+                    attribute_name="num_threads",
+                    parent_fields=["task_parameters"],
+                    required=False,
+                    validator=int,
+                    comment="The number of threads to use for the job",
+                ),
+                Attribute(
+                    attribute_name="batch_size",
+                    parent_fields=["task_parameters"],
+                    required=False,
+                    validator=int,
+                    comment="The number of rows to fetch in each batch",
+                ),
+                Attribute(
+                    attribute_name="primary_id_column",
+                    parent_fields=["task_parameters"],
+                    validator=str,
+                    comment="The primary key column to use for the job",
+                ),
+                Attribute(
+                    attribute_name="secondary_id_column",
+                    parent_fields=["task_parameters"],
+                    validator=str,
+                    required=False,
+                    comment="The secondary key column to use for the job",
+                ),
+                Attribute(
+                    attribute_name="custom_id_column",
+                    parent_fields=["task_parameters"],
+                    validator=str,
+                    required=False,
+                    comment="The custom key column to use for the job",
+                ),
+                Attribute(
+                    attribute_name="model_name",
+                    parent_fields=["task_parameters"],
+                    validator=str,
+                    required=False,
+                    comment="The name of the model. This is going to be a column on the target table. By default it is"
+                            " set to the name of the input <schema>.<table>",
+                ),
+                Attribute(
+                    attribute_name="project_name",
+                    parent_fields=["task_parameters"],
+                    validator=str,
+                    required=False,
+                    comment="The name of the project. This is going to be a column on the target table. By default it is"
+                            " set to feature_store",
+                ),
+                Attribute(
+                    attribute_name="is_deleted_column",
+                    parent_fields=["task_parameters"],
+                    validator=str,
+                    required=False,
+                    comment="The column that has the boolean flag to indicate if the row is deleted",
+                ),
+                Attribute(
+                    attribute_name="hash_column",
+                    parent_fields=["task_parameters"],
+                    validator=str,
+                    required=False,
+                    comment="The column that has the the hash value of the row to be used to get the diff since "
+                            "the last export. If provided, the from_time is required. It's mutually exclusive with "
+                            "updated_at_column",
+                ),
+                Attribute(
+                    attribute_name="updated_at_column",
+                    parent_fields=["task_parameters"],
+                    validator=str,
+                    required=False,
+                    comment="The column that has the last updated timestamp of the row to be used to get the diff "
+                            "since the last export. If provided, the from_time is required. It's mutually exclusive "
+                            "with hash_column",
+                ),
+                Attribute(
+                    attribute_name="from_time",
+                    parent_fields=["task_parameters"],
+                    validator=str,
+                    required=False,
+                    comment="Timestamp in YYYY-mm-ddTHH:MM format. It is used for incremental loads."
+                            "It's required when hash_column or updated_at_column is provided",
+                ),
+                Attribute(
+                    attribute_name="days_to_live",
+                    parent_fields=["task_parameters"],
+                    validator=str,
+                    required=False,
+                    comment="The number of days to keep the data in the table. If provided, the time_to_live attribute "
+                            "will be set in dynamodb",
+                ),
+
+            ]
+        )
+
+    def __init__(self, name, pipeline_name, pipeline, job_config):
+        super().__init__(name, pipeline_name, pipeline, job_config)
+
+        self.executable = self.executable or "reverse_etl.py"
+        self.executable_prefix = self.executable_prefix or "python"
+
+        self._assume_role_arn = self.parse_attribute("assume_role_arn")
+        self._num_threads = self.parse_attribute("num_threads") or 4
+        self._batch_size = self.parse_attribute("batch_size") or 10000
+        self._absolute_job_name = self._absolute_job_name or "common_batch_jobs/reverse_etl"
+        self._primary_id_column = self.parse_attribute("primary_id_column")
+        self._secondary_id_column = self.parse_attribute("secondary_id_column")
+        self._custom_id_column = self.parse_attribute("custom_id_column")
+        self._model_name = self.parse_attribute("model_name")
+        self._project_name = self.parse_attribute("project_name") or "feature_store"
+        self._is_deleted_column = self.parse_attribute("is_deleted_column")
+        self._hash_column = self.parse_attribute("hash_column")
+        self._updated_at_column = self.parse_attribute("updated_at_column")
+        self._from_time = self.parse_attribute("from_time")
+        self._days_to_live = self.parse_attribute("days_to_live")
+
+        if self._hash_column and self._updated_at_column:
+            raise ValueError("hash_column and updated_at_column are mutually exclusive")
+
+        if self._hash_column or self._updated_at_column:
+            if not self._from_time:
+                raise ValueError("from_time is required when hash_column or updated_at_column is provided")
+
+    @property
+    def assume_role_arn(self):
+        return self._assume_role_arn
+
+    @property
+    def num_threads(self):
+        return self._num_threads
+
+    @@property
+    def batch_size(self):
+        return self._batch_size
+
+    @property
+    def primary_id_column(self):
+        return self._primary_id_column
+
+    @property
+    def secondary_id_column(self):
+        return self._secondary_id_column
+
+    @property
+    def custom_id_column(self):
+        return self._custom_id_column
+
+    @property
+    def model_name(self):
+        return self._model_name
+
+    @property
+    def project_name(self):
+        return self._project_name
+
+    @property
+    def is_deleted_column(self):
+        return self._is_deleted_column
+
+    @property
+    def hash_column(self):
+        return self._hash_column
+
+    @property
+    def updated_at_column(self):
+        return self._updated_at_column
+
+    @property
+    def from_time(self):
+        return self._from_time
+
+    @property
+    def days_to_live(self):
+        return self._days_to_live

--- a/dagger/pipeline/tasks/reverse_etl_task.py
+++ b/dagger/pipeline/tasks/reverse_etl_task.py
@@ -8,7 +8,7 @@ class ReverseEtlTask(BatchTask):
     DEFAULT_EXECUTABLE = "reverse_etl.py"
     DEFAULT_NUM_THREADS = 4
     DEFAULT_BATCH_SIZE = 10000
-    DEFAULT_JOB_NAME = "common_batch_jobs/reverse_etl"
+    DEFAULT_JOB_NAME = "common_batch_jobs-reverse_etl"
     DEFAULT_PROJECT_NAME = "feature_store"
 
     @classmethod

--- a/dagger/utilities/config_validator.py
+++ b/dagger/utilities/config_validator.py
@@ -101,6 +101,7 @@ class ConfigValidator:
             parent_attributes = cls.config_attributes[parent_class.__name__]
             current_attributes = cls.config_attributes[cls.__name__]
 
+            # Overwriting attributes in parent operator if they are also existing in the child operator
             merged_attributes = {attr.name: attr for attr in parent_attributes}
             for attr in current_attributes:
                 merged_attributes[attr.name] = attr

--- a/dagger/utilities/config_validator.py
+++ b/dagger/utilities/config_validator.py
@@ -98,10 +98,14 @@ class ConfigValidator:
 
         cls.init_attributes(orig_cls)
         if parent_class.__name__ != "ConfigValidator":
-            cls.config_attributes[cls.__name__] = (
-                cls.config_attributes[parent_class.__name__]
-                + cls.config_attributes[cls.__name__]
-            )
+            parent_attributes = cls.config_attributes[parent_class.__name__]
+            current_attributes = cls.config_attributes[cls.__name__]
+
+            merged_attributes = {attr.name: attr for attr in parent_attributes}
+            for attr in current_attributes:
+                merged_attributes[attr.name] = attr
+
+            cls.config_attributes[cls.__name__] = list(merged_attributes.values())
 
         attributes_lookup = {}
         for index, attribute in enumerate(cls.config_attributes[cls.__name__]):

--- a/tests/fixtures/pipeline/ios/dynamo_io.yaml
+++ b/tests/fixtures/pipeline/ios/dynamo_io.yaml
@@ -1,0 +1,11 @@
+type: dynamo
+name: dynamo_table
+table: schema.table_name                        # The name of the dynamo table
+region_name: eu_west_1
+
+
+# Other attributes:
+
+# has_dependency:                # Weather this i/o should be added to the dependency graph or not. Default is True
+# follow_external_dependency:    # format: dictionary or boolean | External Task Sensor parameters in key value format: https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/sensors/base/index.html
+# region_name:                   # Only needed for cross region dynamo tables

--- a/tests/fixtures/pipeline/ios/sns_io.yaml
+++ b/tests/fixtures/pipeline/ios/sns_io.yaml
@@ -1,0 +1,11 @@
+type: sns
+name: topic_name
+sns_topic: topic_name                        # The name of the dynamo table
+region_name: eu_west_1
+
+
+# Other attributes:
+
+# has_dependency:                # Weather this i/o should be added to the dependency graph or not. Default is True
+# follow_external_dependency:    # format: dictionary or boolean | External Task Sensor parameters in key value format: https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/sensors/base/index.html
+# region_name:                   # Only needed for cross region dynamo tables

--- a/tests/pipeline/ios/test_dynamo_io.py
+++ b/tests/pipeline/ios/test_dynamo_io.py
@@ -1,0 +1,19 @@
+import unittest
+from dagger.pipeline.ios.dynamo_io import DynamoIO
+import yaml
+
+
+class DynamoIOTest(unittest.TestCase):
+    def setUp(self) -> None:
+        with open("tests/fixtures/pipeline/ios/dynamo_io.yaml", "r") as stream:
+            config = yaml.safe_load(stream)
+
+        self.dynamo_io = DynamoIO(config, "/")
+
+    def test_properties(self):
+        self.assertEqual(self.dynamo_io.alias(), "dynamo://eu_west_1/schema.table_name")
+        self.assertEqual(self.dynamo_io.rendered_name, "schema.table_name")
+        self.assertEqual(self.dynamo_io.airflow_name,"dynamo-eu_west_1-schema.table_name")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pipeline/ios/test_sns_io.py
+++ b/tests/pipeline/ios/test_sns_io.py
@@ -1,0 +1,19 @@
+import unittest
+from dagger.pipeline.ios.sns_io import SnsIO
+import yaml
+
+
+class SnsIOTest(unittest.TestCase):
+    def setUp(self) -> None:
+        with open("tests/fixtures/pipeline/ios/sns_io.yaml", "r") as stream:
+            config = yaml.safe_load(stream)
+
+        self.sns_io = SnsIO(config, "/")
+
+    def test_properties(self):
+        self.assertEqual(self.sns_io.alias(), f"sns://eu_west_1/topic_name")
+        self.assertEqual(self.sns_io.rendered_name, "topic_name")
+        self.assertEqual(self.sns_io.airflow_name, "sns-eu_west_1-topic_name")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[DATA-2025](https://choco.atlassian.net/browse/DATA-2025)

The new reverse etl operator is inherited from the batch operator with automatically filling out some of the batch parameters, like job name, input and output task name, target storage type, etc.

- Creating new reverse etl oprator
- Adding dynamo and sns io types
- Fixing some smaller issues that were breaking the cli commands
- Added the possiblity that an inherited operator can overwrite attributes of the base operator. E.g in our case from required to optional.

[DATA-2025]: https://choco.atlassian.net/browse/DATA-2025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ