### PR TITLE
Feature/data 2175 kill timeout spark

### DIFF
--- a/dagger/dag_creator/airflow/operator_creators/spark_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/spark_creator.py
@@ -91,6 +91,7 @@ class SparkCreator(OperatorCreator):
                 job_args=_parse_args(self._template_parameters),
                 spark_args=_parse_spark_args(self._task.spark_args),
                 spark_conf_args=_parse_spark_args(self._task.spark_conf_args, '=', 'conf '),
+                spark_app_name=self._task.spark_conf_args.get("spark.app.name", ""),
                 extra_py_files=self._task.extra_py_files,
                 **kwargs,
             )

--- a/dagger/dag_creator/airflow/operator_creators/spark_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/spark_creator.py
@@ -91,7 +91,7 @@ class SparkCreator(OperatorCreator):
                 job_args=_parse_args(self._template_parameters),
                 spark_args=_parse_spark_args(self._task.spark_args),
                 spark_conf_args=_parse_spark_args(self._task.spark_conf_args, '=', 'conf '),
-                spark_app_name=self._task.spark_conf_args.get("spark.app.name", ""),
+                spark_app_name=self._task.spark_conf_args.get("spark.app.name", None) if self._task.spark_conf_args else None,
                 extra_py_files=self._task.extra_py_files,
                 **kwargs,
             )

--- a/dagger/dag_creator/airflow/operators/spark_submit_operator.py
+++ b/dagger/dag_creator/airflow/operators/spark_submit_operator.py
@@ -4,7 +4,7 @@ import signal
 import time
 
 import boto3
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowTaskTimeout
 from airflow.utils.decorators import apply_defaults
 
 from dagger.dag_creator.airflow.operators.dagger_base_operator import DaggerBaseOperator

--- a/dagger/dag_creator/airflow/operators/spark_submit_operator.py
+++ b/dagger/dag_creator/airflow/operators/spark_submit_operator.py
@@ -71,7 +71,6 @@ class SparkSubmitOperator(DaggerBaseOperator):
         return None
 
     def get_cluster_id_by_name(self, emr_cluster_name, cluster_states):
-
         response = self.emr_client.list_clusters(ClusterStates=cluster_states)
         matching_clusters = list(
             filter(lambda cluster: cluster['Name'] == emr_cluster_name, response['Clusters']))
@@ -87,6 +86,9 @@ class SparkSubmitOperator(DaggerBaseOperator):
 
 
     def get_application_id_by_name(self, emr_master_instance_id, application_name):
+        """
+        Get the application ID of the Spark job
+        """
         command = f"yarn application -list -appStates RUNNING | grep {application_name}"
 
         response = self.ssm_client.send_command(
@@ -149,7 +151,7 @@ class SparkSubmitOperator(DaggerBaseOperator):
         while status in ['Pending', 'InProgress', 'Delayed']:
             time.sleep(30)
             elapsed_time = time.time() - start_time
-            if self._execution_timeout and elapsed_time > self._execution_timeout:
+            if self._execution_timeout and elapsed_time > self._execution_timeout.total_seconds():
                 application_id = self.get_application_id_by_name(emr_master_instance_id,
                                                                  self.spark_conf_args["application_name"])
                 if application_id:

--- a/dagger/dag_creator/airflow/operators/spark_submit_operator.py
+++ b/dagger/dag_creator/airflow/operators/spark_submit_operator.py
@@ -117,51 +117,16 @@ class SparkSubmitOperator(DaggerBaseOperator):
                 CommandId=command_id, InstanceId=emr_master_instance_id
             )
 
-            self.log.info(f"ouotput: {output}")
-
             stdout = output["StandardOutputContent"]
-            self.log.info(f"stdout: {stdout}")
             for line in stdout.split("\n"):
                 if application_name in line:
                     application_id = line.split()[0]
                     return application_id
         return None
 
-    def get_application_id_by_name(self, emr_master_instance_id, application_name):
-        """
-        Get the application ID of the Spark job
-        """
-        if application_name:
-            command = f"yarn application -list -appStates RUNNING | grep {application_name}"
-
-            response = self.ssm_client.send_command(
-                InstanceIds=[emr_master_instance_id],
-                DocumentName="AWS-RunShellScript",
-                Parameters={"commands": [command]}
-            )
-
-            command_id = response['Command']['CommandId']
-            time.sleep(10)  # Wait for the command to execute
-
-            output = self.ssm_client.get_command_invocation(
-                CommandId=command_id,
-                InstanceId=emr_master_instance_id
-            )
-
-            stdout = output['StandardOutputContent']
-            for line in stdout.split('\n'):
-                if application_name in line:
-                    application_id = line.split()[0]
-                    return application_id
-        return None
-
-
     def kill_spark_job(self):
         self._application_id = self.get_application_id_by_name(
             self._emr_master_instance_id, self.spark_app_name
-        )
-        self.log.info(
-            f"emr:{self._emr_master_instance_id}, application_name:{self.spark_app_name}, application_id: {self._application_id}"
         )
         if self._application_id and self._emr_master_instance_id:
             kill_command = f"yarn application -kill {self._application_id}"
@@ -209,12 +174,6 @@ class SparkSubmitOperator(DaggerBaseOperator):
             command_id = response["Command"]["CommandId"]
             status = "Pending"
             status_details = None
-            self._application_id = self.get_application_id_by_name(
-                self._emr_master_instance_id, self.spark_app_name
-            )
-            self.log.info(
-                f"emr:{self._emr_master_instance_id}, application_name:{self.spark_app_name}, application_id: {self._application_id}"
-            )
 
             # Monitor the command's execution
             while status in ["Pending", "InProgress", "Delayed"]:
@@ -241,12 +200,6 @@ class SparkSubmitOperator(DaggerBaseOperator):
                 )
 
         except Exception as e:
-            self._application_id = self.get_application_id_by_name(
-                self._emr_master_instance_id, self.spark_app_name
-            )
-            self.log.info(
-                f"emr:{self._emr_master_instance_id}, application_name:{self.spark_app_name}, application_id: {self._application_id}"
-            )
             logging.error(f"Error encountered: {str(e)}")
             self.kill_spark_job()
             raise AirflowException(f"Task failed with error: {str(e)}")

--- a/dagger/dag_creator/airflow/operators/spark_submit_operator.py
+++ b/dagger/dag_creator/airflow/operators/spark_submit_operator.py
@@ -156,8 +156,13 @@ class SparkSubmitOperator(DaggerBaseOperator):
         return None
 
 
-
     def kill_spark_job(self):
+        self._application_id = self.get_application_id_by_name(
+            self._emr_master_instance_id, self.spark_app_name
+        )
+        self.log.info(
+            f"emr:{self._emr_master_instance_id}, application_name:{self.spark_app_name}, application_id: {self._application_id}"
+        )
         if self._application_id and self._emr_master_instance_id:
             kill_command = f"yarn application -kill {self._application_id}"
             self.ssm_client.send_command(

--- a/dagger/dag_creator/airflow/operators/spark_submit_operator.py
+++ b/dagger/dag_creator/airflow/operators/spark_submit_operator.py
@@ -165,7 +165,3 @@ class SparkSubmitOperator(DaggerBaseOperator):
         if status != 'Success':
             raise AirflowException(f"Spark command failed, check Spark job status in YARN resource manager. "
                                    f"Response status details: {status_details}")
-
-    def on_kill(self):
-        self.log.info("Sending SIGTERM signal to bash process group")
-        os.killpg(os.getpgid(self.sp.pid), signal.SIGTERM)

--- a/dagger/dag_creator/airflow/operators/spark_submit_operator.py
+++ b/dagger/dag_creator/airflow/operators/spark_submit_operator.py
@@ -25,6 +25,7 @@ class SparkSubmitOperator(DaggerBaseOperator):
             job_args=None,
             spark_args=None,
             spark_conf_args=None,
+            spark_app_name=None,
             extra_py_files=None,
             *args,
             **kwargs,
@@ -34,6 +35,7 @@ class SparkSubmitOperator(DaggerBaseOperator):
         self.job_args = job_args
         self.spark_args = spark_args
         self.spark_conf_args = spark_conf_args
+        self.spark_app_name = spark_app_name
         self.extra_py_files = extra_py_files
         self.cluster_name = cluster_name
         self._execution_timeout = kwargs.get('execution_timeout')
@@ -177,7 +179,7 @@ class SparkSubmitOperator(DaggerBaseOperator):
             # Handle task timeout
             self.log.error("Task timed out. Attempting to terminate the Spark job.")
             application_id = self.get_application_id_by_name(
-                emr_master_instance_id, self.spark_conf_args["application_name"]
+                emr_master_instance_id, self.spark_app_name
             )
             if application_id:
                 self.kill_spark_job(emr_master_instance_id, application_id)


### PR DESCRIPTION
Feature:
-  Add spark app name to the spark job
- Function `kill_spark_job` handles the termination of Spark jobs via sending the yarn command to ssm
- Overwrite the function `on_kill` to terminate the spark via calling `kill_spark_job` function when the Airflow task is marked as failed, or manually killed via the Airflow UI or CLI.
- Extend the error Handling in execute: when anything fails in execute, also terminates the spark job via `kill_spark_job`

Tested in datastg:
- timetout in airflow: https://airflow.datastg.choco.com/dags/core-users/grid?dag_run_id=scheduled__2025-01-19T00%3A45%3A00%2B00%3A00&tab=logs&task_id=user_scd_supdater
- marked as failure in airflow: https://airflow.datastg.choco.com/dags/core-users/grid?dag_run_id=scheduled__2025-01-19T00%3A45%3A00%2B00%3A00&tab=logs&task_id=user_scd_supdater