### PR TITLE
Removing unnecessary inputs/outputs from command

### DIFF
--- a/dagger/dag_creator/airflow/operator_creators/dbt_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/dbt_creator.py
@@ -34,7 +34,8 @@ class DbtCreator(BatchCreator):
         if self._create_external_athena_table:
             command.append(f"--create_external_athena_table={self._create_external_athena_table}")
         for param_name, param_value in self._template_parameters.items():
-            command.append(
-                f"--{param_name}={param_value}"
-            )
+            if param_name == 'output_s3_path':
+                command.append(
+                    f"--{param_name}={param_value}"
+                )
         return command


### PR DESCRIPTION
Right now we add all inputs/outputs from the dbt task yaml to the batch command, the thing is we have all the upstream sensors and also the soda sensors and that command is getting pretty big unnecessarily. for one table is even bigger than the size supported by batch