### PR TITLE
feat: add param _columns_to_include and _columns_to_exclude in the reverse_etl task

### DIFF
--- a/dagger/dag_creator/airflow/operator_creators/reverse_etl_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/reverse_etl_creator.py
@@ -33,6 +33,8 @@ class ReverseEtlCreator(BatchCreator):
         self._glue_schema_name = task.glue_schema_name
         self._sort_key = task.sort_key
         self._custom_columns = task.custom_columns
+        self._columns_to_include = task.columns_to_include
+        self._columns_to_exclude = task.columns_to_exclude
 
     def _generate_command(self):
         command = BatchCreator._generate_command(self)
@@ -75,7 +77,10 @@ class ReverseEtlCreator(BatchCreator):
             command.append(f"--sort_key={self._sort_key}")
         if self._custom_columns:
             command.append(f"--custom_columns={self._custom_columns}")
-
+        if self._columns_to_include:
+            command.append(f"--columns_to_include={self._columns_to_include}")
+        if self._columns_to_exclude:
+            command.append(f"--columns_to_exclude={self._columns_to_exclude}")
 
         return command
 

--- a/dagger/dag_creator/airflow/operator_creators/reverse_etl_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/reverse_etl_creator.py
@@ -33,8 +33,8 @@ class ReverseEtlCreator(BatchCreator):
         self._glue_schema_name = task.glue_schema_name
         self._sort_key = task.sort_key
         self._custom_columns = task.custom_columns
-        self._columns_to_include = task.columns_to_include
-        self._columns_to_exclude = task.columns_to_exclude
+        self._input_table_columns_to_include = task.input_table_columns_to_include
+        self._input_table_columns_to_exclude = task.input_table_columns_to_exclude
 
     def _generate_command(self):
         command = BatchCreator._generate_command(self)
@@ -77,10 +77,10 @@ class ReverseEtlCreator(BatchCreator):
             command.append(f"--sort_key={self._sort_key}")
         if self._custom_columns:
             command.append(f"--custom_columns={self._custom_columns}")
-        if self._columns_to_include:
-            command.append(f"--columns_to_include={self._columns_to_include}")
-        if self._columns_to_exclude:
-            command.append(f"--columns_to_exclude={self._columns_to_exclude}")
+        if self._input_table_columns_to_include:
+            command.append(f"--input_table_columns_to_include={self._input_table_columns_to_include}")
+        if self._input_table_columns_to_exclude:
+            command.append(f"--input_table_columns_to_exclude={self._input_table_columns_to_exclude}")
 
         return command
 

--- a/dagger/pipeline/tasks/reverse_etl_task.py
+++ b/dagger/pipeline/tasks/reverse_etl_task.py
@@ -206,7 +206,7 @@ class ReverseEtlTask(BatchTask):
         if self._hash_column and self._updated_at_column:
             raise ValueError(f"ReverseETLTask: {self._name} hash_column and updated_at_column are mutually exclusive")
 
-        if self._input_table_columns_to_include and not self._input_table_columns_to_exclude:
+        if self._input_table_columns_to_include and self._input_table_columns_to_exclude:
             raise ValueError(f"ReverseETLTask: {self._name} _input_table_columns_to_include and _input_table_columns_to_exclude are mutually exclusive")
 
         if self._hash_column or self._updated_at_column:

--- a/dagger/pipeline/tasks/reverse_etl_task.py
+++ b/dagger/pipeline/tasks/reverse_etl_task.py
@@ -158,18 +158,18 @@ class ReverseEtlTask(BatchTask):
                     comment='Optional JSON string for additional custom columns from static values. Example: \'{"custom_project": "ProjectXYZ", "model_name": "ModelABC"}\''
                 ),
                 Attribute(
-                    attribute_name="columns_to_include",
+                    attribute_name="input_table_columns_to_include",
                     parent_fields=["task_parameters"],
                     validator=str,
                     required=False,
-                    comment='Optional comma-separated list of columns to include in the job. Example: \'column1,column2,column3\', if not provided, all columns will be included',
+                    comment='Optional comma-separated list of columns to include in the job. Example: \'column1,column2,column3\', if not provided, all columns of input table will be included',
                 ),
                 Attribute(
-                    attribute_name="columns_to_exclude",
+                    attribute_name="input_table_columns_to_exclude",
                     parent_fields=["task_parameters"],
                     validator=str,
                     required=False,
-                    comment='Optional comma-separated list of columns to exclude from the job. Example: \'column1,column2,column3\', if not provided, all columns will be included',
+                    comment='Optional comma-separated list of columns to exclude from the job. Example: \'column1,column2,column3\', if not provided, all columns of input table will be included',
                 )
             ]
         )
@@ -200,11 +200,14 @@ class ReverseEtlTask(BatchTask):
         self._glue_schema_name = self.parse_attribute("glue_schema_name")
         self._sort_key = self.parse_attribute("sort_key")
         self._custom_columns = self.parse_attribute("custom_columns")
-        self._columns_to_include = self.parse_attribute("columns_to_include")
-        self._columns_to_exclude = self.parse_attribute("columns_to_exclude")
+        self._input_table_columns_to_include = self.parse_attribute("input_table_columns_to_include")
+        self._input_table_columns_to_exclude = self.parse_attribute("input_table_columns_to_exclude")
 
         if self._hash_column and self._updated_at_column:
             raise ValueError(f"ReverseETLTask: {self._name} hash_column and updated_at_column are mutually exclusive")
+
+        if self._input_table_columns_to_include and not self._input_table_columns_to_exclude:
+            raise ValueError(f"ReverseETLTask: {self._name} _input_table_columns_to_include and _input_table_columns_to_exclude are mutually exclusive")
 
         if self._hash_column or self._updated_at_column:
             if not self._from_time:
@@ -325,9 +328,9 @@ class ReverseEtlTask(BatchTask):
         return self._custom_columns
 
     @property
-    def columns_to_include(self):
-        return self._columns_to_include
+    def input_table_columns_to_include(self):
+        return self._input_table_columns_to_include
 
     @property
-    def columns_to_exclude(self):
-        return self._columns_to_exclude
+    def input_table_columns_to_exclude(self):
+        return self._input_table_columns_to_exclude

--- a/dagger/pipeline/tasks/reverse_etl_task.py
+++ b/dagger/pipeline/tasks/reverse_etl_task.py
@@ -156,9 +156,21 @@ class ReverseEtlTask(BatchTask):
                     validator=str,
                     required=False,
                     comment='Optional JSON string for additional custom columns from static values. Example: \'{"custom_project": "ProjectXYZ", "model_name": "ModelABC"}\''
+                ),
+                Attribute(
+                    attribute_name="columns_to_include",
+                    parent_fields=["task_parameters"],
+                    validator=str,
+                    required=False,
+                    comment='Optional comma-separated list of columns to include in the job. Example: \'column1,column2,column3\', if not provided, all columns will be included',
+                ),
+                Attribute(
+                    attribute_name="columns_to_exclude",
+                    parent_fields=["task_parameters"],
+                    validator=str,
+                    required=False,
+                    comment='Optional comma-separated list of columns to exclude from the job. Example: \'column1,column2,column3\', if not provided, all columns will be included',
                 )
-
-
             ]
         )
 
@@ -188,6 +200,8 @@ class ReverseEtlTask(BatchTask):
         self._glue_schema_name = self.parse_attribute("glue_schema_name")
         self._sort_key = self.parse_attribute("sort_key")
         self._custom_columns = self.parse_attribute("custom_columns")
+        self._columns_to_include = self.parse_attribute("columns_to_include")
+        self._columns_to_exclude = self.parse_attribute("columns_to_exclude")
 
         if self._hash_column and self._updated_at_column:
             raise ValueError(f"ReverseETLTask: {self._name} hash_column and updated_at_column are mutually exclusive")
@@ -309,3 +323,11 @@ class ReverseEtlTask(BatchTask):
     @property
     def custom_columns(self):
         return self._custom_columns
+
+    @property
+    def columns_to_include(self):
+        return self._columns_to_include
+
+    @property
+    def columns_to_exclude(self):
+        return self._columns_to_exclude


### PR DESCRIPTION
Add `_input_table_columns_to_include` and `_input_table_columns_to_exclude` to the reverse_etl task param, so that we can choose what fields to upload to the dynamo/glue