### PR TITLE
fix: wrong validator for full_refresh

### DIFF
--- a/dagger/pipeline/tasks/reverse_etl_task.py
+++ b/dagger/pipeline/tasks/reverse_etl_task.py
@@ -104,7 +104,7 @@ class ReverseEtlTask(BatchTask):
                 Attribute(
                     attribute_name="full_refresh",
                     parent_fields=["task_parameters"],
-                    validator=bool,
+                    validator=str,
                     required=False,
                     comment="If set to True, the job will perform a full refresh instead of an incremental one",
                 ),


### PR DESCRIPTION
The `validator=bool` was not working as expected.
This is how it works:
<img width="832" alt="Screenshot 2025-04-25 at 09 50 04" src="https://github.com/user-attachments/assets/e19565f6-cb36-46f3-959d-b11b8958091b" />

if we use validator=bool,
then the parsed_value = bool(input_value)

However, this will be the result of some examples:
```
bool("")      # False, because the empty string is “falsy”
bool("False") # True, because any non‐empty string is “truthy”
bool("foo")   # True
```
So:
"" → False
anything else (e.g. "False", "0", "anything") → True

This is not what we want. So, we should use `str` as validator and then use parse_boolean as type in the python script to handle this input.
