### PR TITLE
parse dagrun_timeout as a timedelta instead of int

### DIFF
--- a/dagger/pipeline/pipeline.py
+++ b/dagger/pipeline/pipeline.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from os.path import join, relpath
 
 from dagger import conf
@@ -71,6 +71,7 @@ class Pipeline(ConfigValidator):
         self._alerts = []
         self._alert_factory = AlertFactory()
         self.process_alerts(config["alerts"] or [])
+        self.process_dag_parameters(self._parameters)
 
     @property
     def directory(self):
@@ -129,3 +130,8 @@ class Pipeline(ConfigValidator):
                         alert_type, join(self.directory, "pipeline.yaml"), alert_config
                     )
                 )
+    def process_dag_parameters(self, dag_parameters):#TODO: create long term fix for this
+        if dag_parameters is not None:
+            for key, value in dag_parameters.items():
+                if key == 'dagrun_timeout':
+                    self._parameters[key] = eval(value)


### PR DESCRIPTION
[DATA-2387](https://choco.atlassian.net/browse/DATA-2387)


After upgrading to Airflow 2.11, there is more strict type checks that are performed. 

As a result, when we use `dagrun_timeout`, like [here](https://github.com/chocoapp/dataeng-airflow-dags/blob/5ef4a71f1e9ec1d7dbc4fddf92f8640dfa2c54b8/dags/dataeng/emr/scale_down/pipeline.yaml#L11) the dags fail to load on airflow because `dagrun_timeout` expects a `timedelta` but we input an `int`.

As a quick fix, I use the `eval` method to evaluate the input `dagrun_timeout`, provided that the value we input is something like `"timedelta(seconds=1500)"`. you can see this [here](https://github.com/chocoapp/dataeng-airflow-dags/blob/0cd44dbdc193fde7f204bc22fea519351ce75126/dags/dataeng/emr/scale_down/pipeline.yaml#L11).

[DATA-2387]: https://choco.atlassian.net/browse/DATA-2387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ